### PR TITLE
Setup kafka broker & V2X-Hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+       - "2181:2182"
+  kafka:
+    image: wurstmeister/kafka
+    depends_on: 
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_CREATE_TOPICS: "v2xhub_in:1:1,v2xhub_out:1:1"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  db:
+    image: usdotfhwaops/mysql:carma-streets
+    container_name: mysql
+    restart: always
+    environment:
+      - MYSQL_DATABASE=IVP
+      - MYSQL_USER=IVP
+      - MYSQL_PASSWORD=ivp
+      - MYSQL_ROOT_PASSWORD=ivp
+      - username=${username}
+      - password=${password}
+    network_mode: host
+  php:
+    image: usdotfhwaops/php:carma-streets
+    container_name: php
+    network_mode: host
+    depends_on:
+      - db
+    stdin_open: true
+    tty: true
+
+  v2xhub:
+    image: usdotfhwaops/v2xhubamd:carma-streets
+    container_name: v2xhub
+    network_mode: host
+    restart: always
+    depends_on:
+      - kafka
+      - php
+    volumes:
+      - ./logs:/var/log/tmx
+      - ./MAP:/var/www/plugins/MAP
+


### PR DESCRIPTION
Created docker-compose file to bring up kafka broker and v2x-hub carma-streets branch. Also included the mysql directory for the localhost.sql file and the script-credentials.sh to create v2x-hub users. To create a v2xhub user a .env file must be created in the carma-streets directory with `username=<username>' and 'password=<password>'. Included web directory for the php web UI for v2xhub and included MAP and log directories for volumes created by v2xhub