### PR TITLE
Fix vehicle status intent tags mismatch issue and configuration parameters for MO/MP timestamp

### DIFF
--- a/message_services/manifest.json
+++ b/message_services/manifest.json
@@ -7,5 +7,6 @@
     "BSM_GROUP_ID": "bsm_consumer",
     "MP_GROUP_ID": "mobilitypath_consumer",
     "MO_GROUP_ID": "mobilityoperation_consumer",
-    "VSI_EST_PATH_COUNT": "0"
+    "VSI_EST_PATH_COUNT": "0",
+    "MO_MP_MAX_TIMESTAMP_DURATION": "100"
 }

--- a/message_services/src/models/vehicle_status_intent.cpp
+++ b/message_services/src/models/vehicle_status_intent.cpp
@@ -113,7 +113,7 @@ namespace message_services
                 writer->Uint64(this->getDepart_position());
                 writer->String("is_allowed");
                 writer->Bool(this->getIs_allowed());
-                writer->String("cur_lanelet_id");
+                writer->String("cur_lane_id");
                 writer->Int64(this->getCur_lanelet_id());
                 writer->String("cur_ds");
                 writer->Double(this->getCur_distance());
@@ -121,7 +121,7 @@ namespace message_services
                 writer->Int64(this->getEnter_lanelet_id());
                 writer->String("dest_lane_id");
                 writer->Int64(this->getDest_lanelet_id());
-                writer->String("link_lanelet_id");
+                writer->String("link_lane_id");
                 writer->Int64(this->getLink_lanelet_id());
                 //Vehicle turn direction at the intersection
                 writer->String("direction");

--- a/message_services/src/services/vehicle_status_intent_service.cpp
+++ b/message_services/src/services/vehicle_status_intent_service.cpp
@@ -63,6 +63,7 @@ namespace message_services
                 }
 
                 this->vsi_est_path_point_count = std::stoi(client->get_value_by_doc(doc, "VSI_EST_PATH_COUNT"));
+                this->MOBILITY_OPERATION_PATH_MAX_DURATION = std::stoi(client->get_value_by_doc(doc, "MO_MP_MAX_TIMESTAMP_DURATION"));
 
                 delete client;
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Combining the MobilityPath and MobilityOperation with vehicle id and timestamp. Added the configuration parameter duration to allow some offsets between the two timestamps. 
Fix the vehicle status and intent tag mismatch issue so that scheduling service can pick it up the data correctly.
<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
UC#1
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
vehicle integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
