### PR TITLE
fixing vehicle speed and max_decel unit conversion issues

### DIFF
--- a/scheduling_service/src/vehicle.cpp
+++ b/scheduling_service/src/vehicle.cpp
@@ -15,9 +15,8 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 
 	if (message["metadata"].HasMember("timestamp") && (double)message["metadata"]["timestamp"].GetInt64() / 1000.0 >= timestamp){
 		
-		/* the unit of the received speed from the message is mile per hour
-		*  but the unit of the speed defined in the vehicle class is meter per second. 
-		*  Therefore, a conversion has been added here.
+		/* the unit of the received speed from the message is meter per second
+		*  the unit of the speed defined in the vehicle class is meter per second. 
 		*/
 		if (message["payload"].HasMember("cur_speed")){
 			speed = message["payload"]["cur_speed"].GetDouble();

--- a/scheduling_service/src/vehicle.cpp
+++ b/scheduling_service/src/vehicle.cpp
@@ -20,7 +20,7 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 		*  Therefore, a conversion has been added here.
 		*/
 		if (message["payload"].HasMember("cur_speed")){
-			speed = message["payload"]["cur_speed"].GetDouble() * 0.44704;
+			speed = message["payload"]["cur_speed"].GetDouble();
 		} else{
 			spdlog::critical("the current speed of Vehicle {0} is missing in the received update!", veh_id);
 		}
@@ -89,7 +89,7 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 			}
 
 			if (message["payload"].HasMember("max_decel")){
-				decel_max = -message["payload"]["max_decel"].GetDouble();
+				decel_max = message["payload"]["max_decel"].GetDouble();
 			} else{
 				spdlog::critical("the maximum decelration of Vehicle {0} is missing in the received update!", veh_id);
 			}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Removing the unit conversion from the vehicle's current speed in the vehicle status and intent message. The unit of the current speed in both the message and the scheduling service is meter/sec.

Removing the negative sign from max_decel value in the received vehicle status and intent message. The received max_decel from the message already has a negative sign.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
