### PR TITLE
scheduling_service bugfix

### DIFF
--- a/scheduling_service/include/configuration.h
+++ b/scheduling_service/include/configuration.h
@@ -31,6 +31,16 @@ class configuration{
 		 */
 		double update_expiration_delta;
 
+		/* stopping distance paramter 
+		*  unit: meter 
+		*/
+		double stopping_distance;
+
+		/* stopping speed parameter 
+		*  unit: meter/sec
+		*/
+		double stopping_speed;
+
 	public:
 
 		/* initialization: reading the EXPIRATION_DELTA from ../manifest.json */
@@ -48,6 +58,12 @@ class configuration{
 		/* get the vehicle status and intent update expiration time interval */
 		double get_expDelta();
 
+		/* get the stopping distance condition */
+		double get_stopDistance();
+
+		/* get the stopping speed condition */
+		double get_stopSpeed();
+
 		/* set the last schedule's start time point to t */
 		void set_lastSchedulingT(double t);
 
@@ -59,6 +75,12 @@ class configuration{
 
 		/* set the vehicle status and intent update expiration time interval to delta*/
 		void set_expDelta(double delta);
+		
+		/* set the stopping distance condition to ds */
+		void set_stopDistance(double ds);
+
+		/* set the stopping speed condition to speed */
+		void set_stopSpeed(double speed);
 };
 
 #endif

--- a/scheduling_service/include/vehicle.h
+++ b/scheduling_service/include/vehicle.h
@@ -9,6 +9,7 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/cfg/env.h"
 
+#include "configuration.h"
 #include "intersection_client.h"
 
 using namespace std;
@@ -122,7 +123,7 @@ class vehicle{
 
 	public:
 
-		void update(const Document& message, intersection_client& localmap);
+		void update(const Document& message, intersection_client& localmap, configuration& config);
 
 		string get_id();
 

--- a/scheduling_service/manifest.json
+++ b/scheduling_service/manifest.json
@@ -3,5 +3,7 @@
     "PRODUCER_TOPIC": "v2xhub_scheduling_plan_sub",
     "CONSUMER_TOPIC": "vehicle_status_intent_output",
     "GROUP_ID": "group_one",
-    "EXPIRATION_DELTA": 300
+    "EXPIRATION_DELTA": 300,
+    "STOP_DISTANCE": 3,
+    "STOP_SPEED": 0.1 
 }

--- a/scheduling_service/src/configuration.cpp
+++ b/scheduling_service/src/configuration.cpp
@@ -40,6 +40,22 @@ configuration::configuration(){
         exit(1);
     }
 
+    if(doc.HasMember("STOP_DISTANCE")){
+        stopping_distance = doc["STOP_DISTANCE"].GetDouble();
+        spdlog::info("stopping_distance :  {0}", stopping_distance);
+    } else{
+        spdlog::critical("Reading {0} failure: {1} is missing in {0}", json_file.c_str(), "STOP_DISTANCE");
+        exit(1);
+    }
+
+    if(doc.HasMember("STOP_SPEED")){
+        stopping_speed = doc["STOP_SPEED"].GetDouble();
+        spdlog::info("stopping_speed :  {0}", stopping_speed);
+    } else{
+        spdlog::critical("Reading {0} failure: {1} is missing in {0}", json_file.c_str(), "STOP_SPEED");
+        exit(1);
+    }
+
 }
 
 /* */
@@ -55,6 +71,12 @@ double configuration::get_curSchedulingT(){return cur_schedule_start_time;}
 double configuration::get_expDelta(){return update_expiration_delta;}
 
 /* */
+double configuration::get_stopDistance(){return stopping_distance;}
+
+/* */
+double configuration::get_stopSpeed(){return stopping_speed;}
+
+/* */
 void configuration::set_lastSchedulingT(double t){last_schedule_start_time = t;}
 
 /* */
@@ -65,4 +87,10 @@ void configuration::set_schedulingDelta(double delta){scheduling_delta = delta;}
 
 /* */
 void configuration::set_expDelta(double delta){update_expiration_delta = delta;}
+
+/* */
+void configuration::set_stopDistance(double ds){stopping_distance = ds;}
+
+/* */
+void configuration::set_stopSpeed(double speed){stopping_speed = speed;}
 

--- a/scheduling_service/src/main.cpp
+++ b/scheduling_service/src/main.cpp
@@ -61,7 +61,7 @@ void consumer_update(const char* paylod){
 
             /* update the vehicle status and intent information */
             if (list_veh.count(veh_id)){
-                list_veh[veh_id].update(message, localmap);       
+                list_veh[veh_id].update(message, localmap, config);       
                 if (list_veh[veh_id].get_curState() == "LV"){
                     list_veh.erase(veh_id);
                 }

--- a/scheduling_service/src/scheduling.cpp
+++ b/scheduling_service/src/scheduling.cpp
@@ -27,7 +27,12 @@ scheduling::scheduling(unordered_map<string, vehicle> list_veh, set<string> list
 			state.push_back(element.second.get_curState());
 
 			departurePosition_index.push_back(element.second.get_departurePosition());
-			distance.push_back(element.second.get_curDistance());
+			if (state.back() == "EV" && element.second.get_curDistance() >= element.second.get_length()){
+				distance.push_back(element.second.get_curDistance() - element.second.get_length());
+			}
+			else{
+				distance.push_back(0.1);
+			}
 			clearance_time.push_back(-1);							// !!!
 			est.push_back(-1);										// !!!
 			st.push_back(element.second.get_actualST());
@@ -62,7 +67,12 @@ scheduling::scheduling(unordered_map<string, vehicle> list_veh, set<string> list
 						
 						time.back() = element.second.get_futureInfo()[i].timestamp;
 						lane_id.back() = element.second.get_futureInfo()[i].lane_id;
-						distance.back() = element.second.get_futureInfo()[i].distance;
+						if (state.back() == "EV" && element.second.get_futureInfo()[i].distance >= element.second.get_length()){
+							distance.back() = element.second.get_futureInfo()[i].distance - element.second.get_length();
+						}
+						else{
+							distance.back() = 0.1;
+						}
 						speed.back() = element.second.get_futureInfo()[i].speed;
 						acceleration.back() = element.second.get_futureInfo()[i].acceleration;
 
@@ -96,7 +106,7 @@ scheduling::scheduling(unordered_map<string, vehicle> list_veh, set<string> list
 			/* if the vehicle is in the EV state, estimate its earliest stopping time */
 			if (state.back() == "EV"){
 
-				double dx1 = max(distance.back(), 0.01);
+				double dx1 = max(distance.back(), 0.1);
 				double dx2 = -pow(speed.back(), 2) / (2 * element.second.get_decelMax());
 				double dx3 = ((pow(localmap.get_laneSpeedLimit(lane_id.back()), 2) - pow(speed.back(), 2)) / (2 * element.second.get_accelMax())) - 
 					(pow(localmap.get_laneSpeedLimit(lane_id.back()), 2) / (2 * element.second.get_decelMax()));

--- a/scheduling_service/src/vehicle.cpp
+++ b/scheduling_service/src/vehicle.cpp
@@ -6,7 +6,7 @@ using namespace rapidjson;
 
 
 /* */
-void vehicle::update(const rapidjson::Document& message, intersection_client& localmap){
+void vehicle::update(const rapidjson::Document& message, intersection_client& localmap, configuration& config){
 	
 	/* the main function will check whether veh_id is included in the message or not
 	*  if it is not included, this function cannot be executed!
@@ -15,11 +15,11 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 
 	if (message["metadata"].HasMember("timestamp") && (double)message["metadata"]["timestamp"].GetInt64() / 1000.0 >= timestamp){
 		
-		/* the unit of the received speed from the message is meter per second
+		/* the unit of the received speed from the message is centimeter per second
 		*  the unit of the speed defined in the vehicle class is meter per second. 
 		*/
 		if (message["payload"].HasMember("cur_speed")){
-			speed = message["payload"]["cur_speed"].GetDouble();
+			speed = message["payload"]["cur_speed"].GetDouble() / 100.0;
 		} else{
 			spdlog::critical("the current speed of Vehicle {0} is missing in the received update!", veh_id);
 		}
@@ -122,7 +122,7 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 			et_actual = -1;
 			dt_actual = -1;
 			if (lane_id == entryLane_id){
-				if (distance <= 2 && speed <= 0.1){
+				if (distance <= config.get_stopDistance() + length && speed <= config.get_stopSpeed()){
 					state = "RDV";
 					st_actual = timestamp;
 				} else{
@@ -147,7 +147,7 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 					lane_id = entryLane_id;
 					distance = 0.1;
 				}
-				if (distance <= 2 && speed <= 0.1){
+				if (distance <= config.get_stopDistance() + length && speed <= config.get_stopSpeed()){
 					state = "RDV";
 					st_actual = timestamp;
 				}
@@ -190,34 +190,49 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 			fi.speed = speed;
 			fi.acceleration = acceleration;
 			future_info.push_back(fi);
-
-			for (SizeType i = 1; i < message["payload"]["est_paths"].Size(); ++i){
-				
-				/* adding checks to make sure the necessary data exist in the future point */
-				if (message["payload"]["est_paths"][i].HasMember("ts") && message["payload"]["est_paths"][i].HasMember("id") && message["payload"]["est_paths"][i].HasMember("ds")){
+			if (message["payload"]["est_paths"].Size() > 1){
+				for (SizeType i = 1; i < message["payload"]["est_paths"].Size(); ++i){
 					
-					/* adding checks to make sure only valid future points will be saved */
-					if (message["payload"]["est_paths"][i]["id"].GetInt() == 0){
-						spdlog::critical("the lane id in the future path of Vehicle {0} is invalid in the received update!", veh_id);
-					}
-					else if (message["payload"]["est_paths"][i]["ds"].GetDouble() < 0){
-						spdlog::critical("the distance to the end of lane in the future path of Vehicle {0} is invalid in the received update!", veh_id);
+					/* adding checks to make sure the necessary data exist in the future point */
+					if (message["payload"]["est_paths"][i].HasMember("ts") && message["payload"]["est_paths"][i].HasMember("id") && message["payload"]["est_paths"][i].HasMember("ds")){
+						
+						/* adding checks to make sure only valid future points will be saved */
+						if (message["payload"]["est_paths"][i]["id"].GetInt() == 0){
+							spdlog::critical("the lane id in the future path of Vehicle {0} is invalid in the received update!", veh_id);
+						}
+						else if (message["payload"]["est_paths"][i]["ds"].GetDouble() < 0){
+							spdlog::critical("the distance to the end of lane in the future path of Vehicle {0} is invalid in the received update!", veh_id);
+						}
+						else{
+
+							future_information fi;
+
+							fi.timestamp = (double)message["payload"]["est_paths"][i]["ts"].GetInt64() / 1000;
+
+							/* the future path received from CARMA Platform does not consider the stopping requirement at the stop bar.
+							*  therefore, CARMA Streets will force the stopping requirement to the vehicle's future path.
+							*  basically, if the vehicle is an EV, or and RDV without access, if the vehicle lane id in the future path is not the same as the vehicle entry lane id, the scheduling service consider the entry lane id as the vehicle future lane id and 0.1 as the distance.
+							* */
+							if ((state == "EV" || (state == "RDV" && access == false)) && to_string(message["payload"]["est_paths"][i]["id"].GetInt()) != entryLane_id){
+								fi.lane_id = entryLane_id;
+								fi.distance = 0.1;
+								fi.speed = 0.0;
+								fi.acceleration = 0.0;
+							}
+							else{
+								fi.lane_id = to_string(message["payload"]["est_paths"][i]["id"].GetInt());
+								fi.distance = message["payload"]["est_paths"][i]["ds"].GetDouble();
+								fi.speed = (fi.distance - future_info[future_info.size() - 1].distance) / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
+								fi.acceleration = (fi.speed - future_info[future_info.size() - 1].speed) / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
+							}
+
+							// spdlog::info("future path {0}: {1}, {2}, {3}, {4}", i, fi.lane_id, fi.distance, fi.speed, fi.acceleration);
+							future_info.push_back(fi);
+						}
 					}
 					else{
-
-						future_information fi;
-
-						fi.timestamp = (double)message["payload"]["est_paths"][i]["ts"].GetInt64() / 1000;
-						fi.lane_id = to_string(message["payload"]["est_paths"][i]["id"].GetInt());
-						fi.distance = message["payload"]["est_paths"][i]["ds"].GetDouble();
-						fi.speed = (fi.distance - future_info[future_info.size() - 1].distance) / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
-						fi.acceleration = (fi.speed - future_info[future_info.size() - 1].speed) / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
-
-						future_info.push_back(fi);
+						spdlog::critical("a point in the future path of Vehicle {0} is not complete in the received update!", veh_id);
 					}
-				}
-				else{
-					spdlog::critical("a point in the future path of Vehicle {0} is not complete in the received update!", veh_id);
 				}
 			}
 		}

--- a/scheduling_service/test/test_vehicle.cpp
+++ b/scheduling_service/test/test_vehicle.cpp
@@ -5,11 +5,13 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/cfg/env.h"
 
+#include "configuration.h"
 #include "intersection_client.h"
 
 TEST(test_vehicle, update)
 {
 
+    configuration config;
     intersection_client localmap;
     localmap.call();
 
@@ -17,13 +19,13 @@ TEST(test_vehicle, update)
     vehicle test_veh;
 
     /* these set of tests make sure that the scheduling service has succesfully added the vehicle information for the first time */
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": 5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 500.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 12.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 12},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 11}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 10}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 9}]}}";
 
     rapidjson::Document message;
     message.SetObject();
     message.Parse(paylod);
 
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
 
     ASSERT_EQ("DOT-507", test_veh.get_id());
     ASSERT_EQ(5, test_veh.get_length());
@@ -41,12 +43,11 @@ TEST(test_vehicle, update)
     ASSERT_EQ(false, test_veh.get_access());
 
     ASSERT_EQ(1623677096.000, test_veh.get_curTime());
-    ASSERT_EQ(7, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is mile per hour
-    *  but the unit of the speed defined in the vehicle class is meter per second. 
-    *  Therefore, a conversion has been added here.
+    ASSERT_EQ(12, test_veh.get_curDistance());
+    /* the unit of the received speed from the message is centimeter per second
+    *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(5 * 0.44704, test_veh.get_curSpeed());
+    ASSERT_EQ(500 / 100, test_veh.get_curSpeed());
     ASSERT_EQ(0, test_veh.get_curAccel());
     ASSERT_EQ("5894", test_veh.get_curLaneID());
 
@@ -59,56 +60,53 @@ TEST(test_vehicle, update)
     for (int i = 0; i < (int)test_veh.get_futureInfo().size(); ++i){
         ASSERT_EQ(1623677096.000 + i*0.2, test_veh.get_futureInfo()[i].timestamp);
         ASSERT_EQ("5894", test_veh.get_futureInfo()[i].lane_id);
-        ASSERT_EQ(7 - i*1, test_veh.get_futureInfo()[i].distance);
+        ASSERT_EQ(12 - i*1, test_veh.get_futureInfo()[i].distance);
     }
 
     /* these set of tests make sure that the scheduling service has succesfully updated the vehicle information from the previous update */
     message["metadata"]["timestamp"].SetInt64(1623677097000);
-    message["payload"]["cur_ds"].SetDouble(2);
-    message["payload"]["cur_speed"].SetDouble(2);
+    message["payload"]["cur_ds"].SetDouble(7);
+    message["payload"]["cur_speed"].SetDouble(200);
     message["payload"]["cur_accel"].SetDouble(-3);
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677097.000, test_veh.get_curTime());
-    ASSERT_EQ(2, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is mile per hour
-    *  but the unit of the speed defined in the vehicle class is meter per second. 
-    *  Therefore, a conversion has been added here.
+    ASSERT_EQ(7, test_veh.get_curDistance());
+    /* the unit of the received speed from the message is centimeter per second
+    *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(2 * 0.44704, test_veh.get_curSpeed());
+    ASSERT_EQ(200 / 100, test_veh.get_curSpeed());
     ASSERT_EQ(-3, test_veh.get_curAccel());
     ASSERT_EQ("5894", test_veh.get_curLaneID());
     ASSERT_EQ("EV", test_veh.get_curState());
 
     /* these set of tests make sure that the scheduling service does not replace the current vehicle information with an old update */
     message["metadata"]["timestamp"].SetInt64(1623677096000);
-    message["payload"]["cur_ds"].SetDouble(7);
-    message["payload"]["cur_speed"].SetDouble(5);
+    message["payload"]["cur_ds"].SetDouble(12);
+    message["payload"]["cur_speed"].SetDouble(500);
     message["payload"]["cur_accel"].SetDouble(0);
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677097.000, test_veh.get_curTime());
-    ASSERT_EQ(2, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is mile per hour
-    *  but the unit of the speed defined in the vehicle class is meter per second. 
-    *  Therefore, a conversion has been added here.
+    ASSERT_EQ(7, test_veh.get_curDistance());
+    /* the unit of the received speed from the message is centimeter per second
+    *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(2 * 0.44704, test_veh.get_curSpeed());
+    ASSERT_EQ(200 / 100, test_veh.get_curSpeed());
     ASSERT_EQ(-3, test_veh.get_curAccel());
     ASSERT_EQ("5894", test_veh.get_curLaneID());
     ASSERT_EQ("EV", test_veh.get_curState());
 
     /* these set of tests make sure that the scheduling service can succesfully updated the vehicle state */
     message["metadata"]["timestamp"].SetInt64(1623677098000);
-    message["payload"]["cur_ds"].SetDouble(0);
+    message["payload"]["cur_ds"].SetDouble(5);
     message["payload"]["cur_speed"].SetDouble(0);
     message["payload"]["cur_accel"].SetDouble(-2);
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677098.000, test_veh.get_curTime());
-    ASSERT_EQ(0, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is mile per hour
-    *  but the unit of the speed defined in the vehicle class is meter per second. 
-    *  Therefore, a conversion has been added here.
+    ASSERT_EQ(5, test_veh.get_curDistance());
+    /* the unit of the received speed from the message is centimeter per second
+    *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(0 * 0.44704, test_veh.get_curSpeed());
+    ASSERT_EQ(0, test_veh.get_curSpeed());
     ASSERT_EQ(-2, test_veh.get_curAccel());
     ASSERT_EQ("5894", test_veh.get_curLaneID());
     ASSERT_EQ("RDV", test_veh.get_curState());
@@ -116,14 +114,14 @@ TEST(test_vehicle, update)
 
     message["metadata"]["timestamp"].SetInt64(1623677099000);
     message["payload"]["cur_accel"].SetDouble(0);
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677099.000, test_veh.get_curTime());
     ASSERT_EQ("RDV", test_veh.get_curState());
     EXPECT_EQ(1623677098.000, test_veh.get_actualST());
 
     message["metadata"]["timestamp"].SetInt64(1623677100000);
     message["payload"]["is_allowed"].SetBool(true);
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677100.000, test_veh.get_curTime()); 
     ASSERT_EQ("23016", test_veh.get_curLaneID());
     ASSERT_EQ(localmap.get_laneLength(test_veh.get_curLaneID()), test_veh.get_curDistance());
@@ -134,16 +132,15 @@ TEST(test_vehicle, update)
     message["metadata"]["timestamp"].SetInt64(1623677101000);
     message["payload"]["cur_lane_id"].SetInt(23016);
     message["payload"]["cur_ds"].SetDouble(18);
-    message["payload"]["cur_speed"].SetDouble(2);
+    message["payload"]["cur_speed"].SetDouble(200);
     message["payload"]["cur_accel"].SetDouble(2);
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677101.000, test_veh.get_curTime());
     ASSERT_EQ(18, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is mile per hour
-    *  but the unit of the speed defined in the vehicle class is meter per second. 
-    *  Therefore, a conversion has been added here.
+    /* the unit of the received speed from the message is centimeter per second
+    *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(2 * 0.44704, test_veh.get_curSpeed());
+    ASSERT_EQ(200 / 100, test_veh.get_curSpeed());
     ASSERT_EQ(2, test_veh.get_curAccel());
     ASSERT_EQ("23016", test_veh.get_curLaneID());
     ASSERT_EQ("DV", test_veh.get_curState());
@@ -153,16 +150,15 @@ TEST(test_vehicle, update)
     message["metadata"]["timestamp"].SetInt64(1623677105000);
     message["payload"]["cur_lane_id"].SetInt(11899);
     message["payload"]["cur_ds"].SetDouble(295);
-    message["payload"]["cur_speed"].SetDouble(10);
+    message["payload"]["cur_speed"].SetDouble(1000);
     message["payload"]["cur_accel"].SetDouble(0);
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677105.000, test_veh.get_curTime());
     ASSERT_EQ(295, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is mile per hour
-    *  but the unit of the speed defined in the vehicle class is meter per second. 
-    *  Therefore, a conversion has been added here.
+    /* the unit of the received speed from the message is centimeter per second
+    *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(10 * 0.44704, test_veh.get_curSpeed());
+    ASSERT_EQ(1000 / 100, test_veh.get_curSpeed());
     ASSERT_EQ(0, test_veh.get_curAccel());
     ASSERT_EQ("11899", test_veh.get_curLaneID());
     ASSERT_EQ("LV", test_veh.get_curState());
@@ -175,21 +171,20 @@ TEST(test_vehicle, update)
 
 TEST(test_vehicle, set_departurePosition){
 
-    // osm localmap("osm.json");
+    configuration config;
     intersection_client localmap;
     localmap.call();
 
 
     vehicle test_veh;
 
-    /* these set of tests make sure that the scheduling service has succesfully added the vehicle information for the first time */
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": 5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
 
     rapidjson::Document message;
     message.SetObject();
     message.Parse(paylod);
 
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
 
     ASSERT_LE(0, test_veh.get_departurePosition());
     test_veh.set_departurePosition(5);
@@ -199,21 +194,20 @@ TEST(test_vehicle, set_departurePosition){
 
 TEST(test_vehicle, set_flexEt){
 
-    // osm localmap("osm.json");
+    configuration config;
     intersection_client localmap;
     localmap.call();
 
 
     vehicle test_veh;
 
-    /* these set of tests make sure that the scheduling service has succesfully added the vehicle information for the first time */
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": 5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
 
     rapidjson::Document message;
     message.SetObject();
     message.Parse(paylod);
 
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
 
     ASSERT_LE(0, test_veh.get_flexET());
     test_veh.set_flexEt(3);
@@ -223,21 +217,20 @@ TEST(test_vehicle, set_flexEt){
 
 TEST(test_vehicle, set_flexST){
 
-    // osm localmap("osm.json");
+    configuration config;
     intersection_client localmap;
     localmap.call();
 
 
     vehicle test_veh;
 
-    /* these set of tests make sure that the scheduling service has succesfully added the vehicle information for the first time */
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": 5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
 
     rapidjson::Document message;
     message.SetObject();
     message.Parse(paylod);
 
-    test_veh.update(message, localmap);
+    test_veh.update(message, localmap, config);
 
     ASSERT_LE(0, test_veh.get_flexST());
     test_veh.set_flexSt(4.6);

--- a/scripts/vehicle_status_intent_test_access.json
+++ b/scripts/vehicle_status_intent_test_access.json
@@ -7,13 +7,13 @@
             },
             "payload": {
                 "v_id": "DOT-507",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
-                "cur_speed": 2.0,
+                "cur_speed": 200.0,
                 "cur_accel": -3.0,
                 "cur_lane_id": 5894,
                 "cur_ds": 2.0,
@@ -63,13 +63,13 @@
             },
             "payload": {
                 "v_id": "DOT-508",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
-                "cur_speed": 5.0,
+                "cur_speed": 500.0,
                 "cur_accel": 0.0,
                 "cur_lane_id": 19252,
                 "cur_ds": 7.0,
@@ -119,13 +119,13 @@
             },
             "payload": {
                 "v_id": "DOT-509",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
-                "cur_speed": 5.0,
+                "cur_speed": 500.0,
                 "cur_accel": 0.0,
                 "cur_lane_id": 13021,
                 "cur_ds": 7.0,
@@ -175,11 +175,11 @@
             },
             "payload": {
                 "v_id": "DOT-507",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": -2,
@@ -231,13 +231,13 @@
             },
             "payload": {
                 "v_id": "DOT-508",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
-                "cur_speed": 2,
+                "cur_speed": 200,
                 "cur_accel": -3,
                 "cur_lane_id": 19252,
                 "cur_ds": 2,
@@ -287,13 +287,13 @@
             },
             "payload": {
                 "v_id": "DOT-509",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
-                "cur_speed": 2,
+                "cur_speed": 200,
                 "cur_accel": -3,
                 "cur_lane_id": 13021,
                 "cur_ds": 2,
@@ -343,11 +343,11 @@
             },
             "payload": {
                 "v_id": "DOT-507",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,
@@ -399,11 +399,11 @@
             },
             "payload": {
                 "v_id": "DOT-508",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": -2,
@@ -455,11 +455,11 @@
             },
             "payload": {
                 "v_id": "DOT-509",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": -2,
@@ -511,11 +511,11 @@
             },
             "payload": {
                 "v_id": "DOT-507",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,
@@ -567,11 +567,11 @@
             },
             "payload": {
                 "v_id": "DOT-508",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,
@@ -623,11 +623,11 @@
             },
             "payload": {
                 "v_id": "DOT-509",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,
@@ -679,13 +679,13 @@
             },
             "payload": {
                 "v_id": "DOT-507",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
-                "cur_speed": 2,
+                "cur_speed": 200,
                 "cur_accel": 2,
                 "cur_lane_id": 23490,
                 "cur_ds": 18,
@@ -735,11 +735,11 @@
             },
             "payload": {
                 "v_id": "DOT-508",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,
@@ -791,11 +791,11 @@
             },
             "payload": {
                 "v_id": "DOT-509",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,
@@ -847,13 +847,13 @@
             },
             "payload": {
                 "v_id": "DOT-507",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
-                "cur_speed": 10,
+                "cur_speed": 1000,
                 "cur_accel": 0,
                 "cur_lane_id": 11899,
                 "cur_ds": 200,
@@ -903,11 +903,11 @@
             },
             "payload": {
                 "v_id": "DOT-508",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,
@@ -959,11 +959,11 @@
             },
             "payload": {
                 "v_id": "DOT-509",
-                "v_length": 5,
+                "v_length": 500,
                 "min_gap": 10,
                 "react_t": 1.5,
                 "max_accel": 5,
-                "max_decel": 5,
+                "max_decel": -5,
 
                 "cur_speed": 0,
                 "cur_accel": 0,


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Adding a unit conversion to the cur_speed.
Making the stopping distance and speed configurable parameters.
Considering vehicle length for the stop condition.
Adding a check for reading the future path info if the vehicle did not receive access and the future path enters the intersection box.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
