### PR TITLE
adding a check before processing the status and intent message

### DIFF
--- a/scheduling_service/include/configuration.h
+++ b/scheduling_service/include/configuration.h
@@ -41,6 +41,11 @@ class configuration{
 		*/
 		double stopping_speed;
 
+		/* maximum valid speed (a speed higher than this parameter will count as an invalid speed)
+		*  unit: meter/sec
+		*/
+		double max_valid_speed;
+
 	public:
 
 		/* initialization: reading the EXPIRATION_DELTA from ../manifest.json */
@@ -64,6 +69,9 @@ class configuration{
 		/* get the stopping speed condition */
 		double get_stopSpeed();
 
+		/* get the max valid speed */
+		double get_maxValidSpeed();
+
 		/* set the last schedule's start time point to t */
 		void set_lastSchedulingT(double t);
 
@@ -81,6 +89,9 @@ class configuration{
 
 		/* set the stopping speed condition to speed */
 		void set_stopSpeed(double speed);
+
+		/* set the max valid speed to speed */
+		void set_maxValidSpeed(double speed);
 };
 
 #endif

--- a/scheduling_service/include/scheduling.h
+++ b/scheduling_service/include/scheduling.h
@@ -104,7 +104,7 @@ class scheduling{
 
 	public:
 
-		scheduling(unordered_map<string, vehicle> list_veh, set<string> list_veh_confirmation, intersection_client& localmap, configuration& config);
+		scheduling(unordered_map<string, vehicle> list_veh, set<string>& list_veh_confirmation, intersection_client& localmap, configuration& config, set<string>& list_veh_removal);
 
 		vector<string> get_vehicleIdList();
 		unordered_map<string, int> get_vehicleIndexList();

--- a/scheduling_service/include/vehicle.h
+++ b/scheduling_service/include/vehicle.h
@@ -58,6 +58,9 @@ class vehicle{
 		/* vehicle's entry lane id */
 		string entryLane_id;
 
+		/* vehicle's departure lane id */
+		string exitLane_id;
+
 		/* vehicle's connection link id */
 		string link_id;
 
@@ -125,6 +128,8 @@ class vehicle{
 
 		void update(const Document& message, intersection_client& localmap, configuration& config);
 
+		bool message_hasError(const Document& message, intersection_client& localmap);
+
 		string get_id();
 
 		double get_length();
@@ -135,6 +140,7 @@ class vehicle{
 		
 		string get_direction();
 		string get_entryLaneID();
+		string get_exitLaneID();
 		string get_linkID();
 		int get_linkPriority();
 		

--- a/scheduling_service/manifest.json
+++ b/scheduling_service/manifest.json
@@ -5,5 +5,6 @@
     "GROUP_ID": "group_one",
     "EXPIRATION_DELTA": 300,
     "STOP_DISTANCE": 3,
-    "STOP_SPEED": 0.1 
+    "STOP_SPEED": 0.1 ,
+    "MAX_VALID_SPEED": 50
 }

--- a/scheduling_service/src/configuration.cpp
+++ b/scheduling_service/src/configuration.cpp
@@ -56,6 +56,14 @@ configuration::configuration(){
         exit(1);
     }
 
+    if(doc.HasMember("MAX_VALID_SPEED")){
+        max_valid_speed = doc["MAX_VALID_SPEED"].GetDouble();
+        spdlog::info("max_valid_speed :  {0}", max_valid_speed);
+    } else{
+        spdlog::critical("Reading {0} failure: {1} is missing in {0}", json_file.c_str(), "MAX_VALID_SPEED");
+        exit(1);
+    }
+
 }
 
 /* */
@@ -77,6 +85,9 @@ double configuration::get_stopDistance(){return stopping_distance;}
 double configuration::get_stopSpeed(){return stopping_speed;}
 
 /* */
+double configuration::get_maxValidSpeed(){return max_valid_speed;}
+
+/* */
 void configuration::set_lastSchedulingT(double t){last_schedule_start_time = t;}
 
 /* */
@@ -93,4 +104,7 @@ void configuration::set_stopDistance(double ds){stopping_distance = ds;}
 
 /* */
 void configuration::set_stopSpeed(double speed){stopping_speed = speed;}
+
+/* */
+void configuration::set_maxValidSpeed(double speed){max_valid_speed = speed;}
 

--- a/scheduling_service/src/main.cpp
+++ b/scheduling_service/src/main.cpp
@@ -61,9 +61,12 @@ void consumer_update(const char* paylod){
 
             /* update the vehicle status and intent information */
             if (list_veh.count(veh_id)){
-                list_veh[veh_id].update(message, localmap, config);       
-                if (list_veh[veh_id].get_curState() == "LV"){
-                    list_veh.erase(veh_id);
+                /* adding a check to not read the messages with wrong BSM */
+                if (list_veh[veh_id].message_hasError(message, localmap) == false){
+                    list_veh[veh_id].update(message, localmap, config);       
+                    if (list_veh[veh_id].get_curState() == "LV"){
+                        list_veh.erase(veh_id);
+                    }
                 }
             }
         }

--- a/scheduling_service/src/main.cpp
+++ b/scheduling_service/src/main.cpp
@@ -32,6 +32,7 @@ configuration config;
 intersection_client localmap;
 unordered_map<string, vehicle> list_veh;
 set<string> list_veh_confirmation;
+set<string> list_veh_removal;
 
 
 void consumer_update(const char* paylod){
@@ -65,6 +66,7 @@ void consumer_update(const char* paylod){
                 if (list_veh[veh_id].message_hasError(message, localmap) == false){
                     list_veh[veh_id].update(message, localmap, config);       
                     if (list_veh[veh_id].get_curState() == "LV"){
+                        spdlog::info("Vehicle {0} has departed the intersection box (i.e., is in LV state) and been removed from list_veh", veh_id);
                         list_veh.erase(veh_id);
                     }
                 }
@@ -77,11 +79,12 @@ void consumer_update(const char* paylod){
     else{
         spdlog::critical("payload is missing in the received status and intent update!");
     }
+
 }
 
 rapidjson::Value scheduling_func(unordered_map<string, vehicle> list_veh, Document::AllocatorType& allocator){
 
-    scheduling schedule(list_veh, list_veh_confirmation, localmap, config);
+    scheduling schedule(list_veh, list_veh_confirmation, localmap, config, list_veh_removal);
 
     /* estimate the departure times (DTs) of DVs */
     for (auto & vehicle_index : schedule.get_indexDVs()){
@@ -446,6 +449,14 @@ void call_consumer_thread()
         
         while (consumer_worker->is_running()) 
         {
+            
+            /* remove those vehicles with old updates */
+            if (list_veh_removal.size() > 0){
+                for (auto veh_id : list_veh_removal){
+                    list_veh.erase(veh_id);
+                }
+                list_veh_removal.clear();
+            } 
 
             const char* paylod= consumer_worker->consume(1000);
 

--- a/scheduling_service/src/scheduling.cpp
+++ b/scheduling_service/src/scheduling.cpp
@@ -6,7 +6,7 @@ using namespace std;
 
 
 /* */
-scheduling::scheduling(unordered_map<string, vehicle> list_veh, set<string> list_veh_confirmation, intersection_client& localmap, configuration& config){
+scheduling::scheduling(unordered_map<string, vehicle> list_veh, set<string>& list_veh_confirmation, intersection_client& localmap, configuration& config, set<string>& list_veh_removal){
 
 	index_EVs.resize(localmap.get_laneIdEntry().size());
 	for (auto& element : list_veh){
@@ -181,6 +181,8 @@ scheduling::scheduling(unordered_map<string, vehicle> list_veh, set<string> list
 			if (list_veh_confirmation.find(element.first) != list_veh_confirmation.end()){
 				list_veh_confirmation.erase(element.first);
 			}
+			spdlog::info("Vehicle {0} is not added to the schedule as its update is more than {1} seconds old!", element.first, config.get_expDelta());
+			list_veh_removal.insert(element.first);
 		}
 	}
 

--- a/scheduling_service/src/vehicle.cpp
+++ b/scheduling_service/src/vehicle.cpp
@@ -291,10 +291,10 @@ bool vehicle::message_hasError(const Document& message, intersection_client& loc
 			return false;
 		}
 	} 
-	/* if it is not the first time processing the vehicle update, the vehicle cur_lane_id must be the same as entry_lane_id, link_lane_id, or depart_lane_id . */
+	/* if a vehicle update has been succesfully processed before, the vehicle cur_lane_id must be the same as entry_lane_id, link_lane_id, or depart_lane_id . */
 	else{
 		string veh_id = message["payload"]["v_id"].GetString();
-		if (to_string(message["payload"]["cur_lane_id"].GetInt()) != entryLane_id && to_string(message["payload"]["cur_lane_id"].GetInt()) != link_id && to_string(message["payload"]["cur_lane_id"].GetInt()) != exitLane_id){
+		if (to_string(message["payload"]["cur_lane_id"].GetInt()) != entryLane_id && to_string(message["payload"]["cur_lane_id"].GetInt()) != link_id && to_string(message["payload"]["cur_lane_id"].GetSInt()) != exitLane_id){
 			
 			spdlog::critical("the current lane id of Vehicle {0} is not correct! entry_lane_id: {1}, link_lane_id: {2}, exit_lane_id: {3}, cur_lane_id: {4}", veh_id, entryLane_id, link_id, exitLane_id, to_string(message["payload"]["cur_lane_id"].GetInt()));
 			return true;

--- a/scheduling_service/src/vehicle.cpp
+++ b/scheduling_service/src/vehicle.cpp
@@ -15,22 +15,22 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 
 	if (message["metadata"].HasMember("timestamp") && (double)message["metadata"]["timestamp"].GetInt64() / 1000.0 >= timestamp){
 		
-		/* the unit of the received speed from the message is centimeter per second
+		/* the unit of the received speed from the message is 0.02 of meter per second
 		*  the unit of the speed defined in the vehicle class is meter per second. 
 		*/
 		if (message["payload"].HasMember("cur_speed")){
-			if (message["payload"]["cur_speed"].GetDouble() / 100.0 > config.get_maxValidSpeed() && id != "" && message["payload"].HasMember("cur_ds") && message["payload"].HasMember("cur_lane_id")){
+			if (message["payload"]["cur_speed"].GetDouble() * 0.02 > config.get_maxValidSpeed() && id != "" && message["payload"].HasMember("cur_ds") && message["payload"].HasMember("cur_lane_id")){
 				if (to_string(message["payload"]["cur_lane_id"].GetInt()) == lane_id){
 					speed = (distance - message["payload"]["cur_ds"].GetDouble()) / (((double)message["metadata"]["timestamp"].GetInt64() / 1000.0) - timestamp);
 				}
 				else{
 					speed = (distance + (localmap.get_laneLength(to_string(message["payload"]["cur_lane_id"].GetInt())) - message["payload"]["cur_ds"].GetDouble())) / (((double)message["metadata"]["timestamp"].GetInt64() / 1000.0) - timestamp);
 				}
-				double invalid_speed = message["payload"]["cur_speed"].GetDouble() / 100.0;
+				double invalid_speed = message["payload"]["cur_speed"].GetDouble() * 0.02;
 				spdlog::info("Invalid speed in the message received from {0}: {1}", veh_id, invalid_speed);
 			}
 			else{
-				speed = message["payload"]["cur_speed"].GetDouble() / 100.0;
+				speed = message["payload"]["cur_speed"].GetDouble() * 0.02;
 				spdlog::info("valid speed in the message received from {0}: {1}", veh_id, speed);
 			}
 		} else{

--- a/scheduling_service/test/test_vehicle.cpp
+++ b/scheduling_service/test/test_vehicle.cpp
@@ -44,10 +44,10 @@ TEST(test_vehicle, update)
 
     ASSERT_EQ(1623677096.000, test_veh.get_curTime());
     ASSERT_EQ(12, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is centimeter per second
+    /* the unit of the received speed from the message is 0.02 of meter per second
     *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(500 / 100, test_veh.get_curSpeed());
+    ASSERT_EQ(500 * 0.02, test_veh.get_curSpeed());
     ASSERT_EQ(0, test_veh.get_curAccel());
     ASSERT_EQ("5894", test_veh.get_curLaneID());
 
@@ -71,10 +71,10 @@ TEST(test_vehicle, update)
     test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677097.000, test_veh.get_curTime());
     ASSERT_EQ(7, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is centimeter per second
+    /* the unit of the received speed from the message is 0.02 of meter per second
     *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(200 / 100, test_veh.get_curSpeed());
+    ASSERT_EQ(200 * 0.02, test_veh.get_curSpeed());
     ASSERT_EQ(-3, test_veh.get_curAccel());
     ASSERT_EQ("5894", test_veh.get_curLaneID());
     ASSERT_EQ("EV", test_veh.get_curState());
@@ -87,10 +87,10 @@ TEST(test_vehicle, update)
     test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677097.000, test_veh.get_curTime());
     ASSERT_EQ(7, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is centimeter per second
+    /* the unit of the received speed from the message is 0.02 of meter per second
     *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(200 / 100, test_veh.get_curSpeed());
+    ASSERT_EQ(200 * 0.02, test_veh.get_curSpeed());
     ASSERT_EQ(-3, test_veh.get_curAccel());
     ASSERT_EQ("5894", test_veh.get_curLaneID());
     ASSERT_EQ("EV", test_veh.get_curState());
@@ -103,7 +103,7 @@ TEST(test_vehicle, update)
     test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677098.000, test_veh.get_curTime());
     ASSERT_EQ(5, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is centimeter per second
+    /* the unit of the received speed from the message is 0.02 of meter per second
     *  the unit of the speed defined in the vehicle class is meter per second. 
     */
     ASSERT_EQ(0, test_veh.get_curSpeed());
@@ -137,10 +137,10 @@ TEST(test_vehicle, update)
     test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677101.000, test_veh.get_curTime());
     ASSERT_EQ(18, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is centimeter per second
+    /* the unit of the received speed from the message is 0.02 of meter per second
     *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(200 / 100, test_veh.get_curSpeed());
+    ASSERT_EQ(200 * 0.02, test_veh.get_curSpeed());
     ASSERT_EQ(2, test_veh.get_curAccel());
     ASSERT_EQ("23016", test_veh.get_curLaneID());
     ASSERT_EQ("DV", test_veh.get_curState());
@@ -155,10 +155,10 @@ TEST(test_vehicle, update)
     test_veh.update(message, localmap, config);
     ASSERT_EQ(1623677105.000, test_veh.get_curTime());
     ASSERT_EQ(295, test_veh.get_curDistance());
-    /* the unit of the received speed from the message is centimeter per second
+    /* the unit of the received speed from the message is 0.02 of meter per second
     *  the unit of the speed defined in the vehicle class is meter per second. 
     */
-    ASSERT_EQ(1000 / 100, test_veh.get_curSpeed());
+    ASSERT_EQ(1000 * 0.02, test_veh.get_curSpeed());
     ASSERT_EQ(0, test_veh.get_curAccel());
     ASSERT_EQ("11899", test_veh.get_curLaneID());
     ASSERT_EQ("LV", test_veh.get_curState());

--- a/scheduling_service/test/test_vehicle.cpp
+++ b/scheduling_service/test/test_vehicle.cpp
@@ -19,7 +19,7 @@ TEST(test_vehicle, update)
     vehicle test_veh;
 
     /* these set of tests make sure that the scheduling service has succesfully added the vehicle information for the first time */
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 500.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 12.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 12},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 11}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 10}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 9}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 500.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 12.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"dest_lane_id\": 12459, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 12},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 11}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 10}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 9}]}}";
 
     rapidjson::Document message;
     message.SetObject();
@@ -178,7 +178,7 @@ TEST(test_vehicle, set_departurePosition){
 
     vehicle test_veh;
 
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"dest_lane_id\": 12459, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
 
     rapidjson::Document message;
     message.SetObject();
@@ -201,7 +201,7 @@ TEST(test_vehicle, set_flexEt){
 
     vehicle test_veh;
 
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"dest_lane_id\": 12459, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
 
     rapidjson::Document message;
     message.SetObject();
@@ -224,7 +224,7 @@ TEST(test_vehicle, set_flexST){
 
     vehicle test_veh;
 
-    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
+    const char* paylod = "{\"metadata\": {\"timestamp\": 1623677096000}, \"payload\": {\"v_id\": \"DOT-507\", \"v_length\": 500, \"min_gap\": 10, \"react_t\": 1.5, \"max_accel\": 5, \"max_decel\": -5, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 5894, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 5894, \"dest_lane_id\": 12459, \"link_lane_id\": 23016, \"is_allowed\": false, \"est_paths\": [{\"ts\": 1623677096000, \"id\": 5894, \"ds\": 7},{\"ts\": 1623677096200, \"id\": 5894, \"ds\": 6}, {\"ts\": 1623677096400, \"id\": 5894, \"ds\": 5}, {\"ts\": 1623677096600, \"id\": 5894, \"ds\": 4}]}}";
 
     rapidjson::Document message;
     message.SetObject();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Add a check to the scheduling_service to make sure the received status and intent message has a valid cur_lane_id.

## Related Issue
https://github.com/usdot-fhwa-stol/carma-streets/issues/55
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
