### PR TITLE
fix est_path distance reading logic

### DIFF
--- a/scheduling_service/src/vehicle.cpp
+++ b/scheduling_service/src/vehicle.cpp
@@ -208,79 +208,46 @@ void vehicle::update(const rapidjson::Document& message, intersection_client& lo
 			fi.speed = speed;
 			fi.acceleration = acceleration;
 			future_info.push_back(fi);
-			if (message["payload"]["est_paths"].Size() > 1){
-				for (SizeType i = 0; i < message["payload"]["est_paths"].Size(); ++i){
+			for (SizeType i = 0; i < message["payload"]["est_paths"].Size(); ++i){
+				
+				/* adding checks to make sure the necessary data exist in the future point */
+				if (message["payload"]["est_paths"][i].HasMember("ts") && message["payload"]["est_paths"][i].HasMember("id") && message["payload"]["est_paths"][i].HasMember("ds")){
 					
-					/* adding checks to make sure the necessary data exist in the future point */
-					if (message["payload"]["est_paths"][i].HasMember("ts") && message["payload"]["est_paths"][i].HasMember("id") && message["payload"]["est_paths"][i].HasMember("ds")){
-						
-						/* adding checks to make sure only valid future points will be saved */
-						if (message["payload"]["est_paths"][i]["id"].GetInt() == 0){
-							spdlog::critical("the lane id in the future path of Vehicle {0} is invalid in the received update!", veh_id);
-						}
-						else if (message["payload"]["est_paths"][i]["ds"].GetDouble() < 0){
-							spdlog::critical("the distance to the end of lane in the future path of Vehicle {0} is invalid in the received update!", veh_id);
-						}
-						else{
-
-
-							/* the future path received from CARMA Platform does not consider the stopping requirement at the stop bar.
-							*  therefore, CARMA Streets will force the stopping requirement to the vehicle's future path.
-							*  basically, if the vehicle is an EV, or and RDV without access, if the vehicle lane id in the future path is not the same as the vehicle entry lane id, the scheduling service will ignore the future points.
-							* */
-							if ((state == "EV" || (state == "RDV" && access == false)) && (to_string(message["payload"]["est_paths"][i]["id"].GetInt()) != entryLane_id || future_info[future_info.size() - 1].distance < message["payload"]["est_paths"][i]["ds"].GetDouble())){
-								spdlog::critical("Vehicle Class log - vehicle {0}: est_path point is not located in an entry lane!", veh_id);
-								break;
-							}
-							else{
-								
-								fi = future_information();
-								fi.timestamp = (double)message["payload"]["est_paths"][i]["ts"].GetInt64() / 1000;
-								if (future_info[future_info.size() - 1].distance >= message["payload"]["est_paths"][i]["ds"].GetDouble()) {
-									fi.distance = future_info[future_info.size() - 1].distance - message["payload"]["est_paths"][i]["ds"].GetDouble();
-									fi.lane_id = to_string(message["payload"]["est_paths"][i]["id"].GetInt());
-								} else{
-									if (future_info[future_info.size() - 1].lane_id == entryLane_id){
-										if (future_info[future_info.size() - 1].distance + localmap.get_laneLength(link_id) >= message["payload"]["est_paths"][i]["ds"].GetDouble()){
-											fi.distance = future_info[future_info.size() - 1].distance + localmap.get_laneLength(link_id) - message["payload"]["est_paths"][i]["ds"].GetDouble();
-											fi.lane_id = link_id;
-										} 
-										else if (future_info[future_info.size() - 1].distance + localmap.get_laneLength(link_id) + localmap.get_laneLength(exitLane_id) >= message["payload"]["est_paths"][i]["ds"].GetDouble()){
-											fi.distance = future_info[future_info.size() - 1].distance + localmap.get_laneLength(link_id) + localmap.get_laneLength(exitLane_id) - message["payload"]["est_paths"][i]["ds"].GetDouble();
-											fi.lane_id = exitLane_id;
-										}
-										else {
-											break;
-										}
-									}
-									else if (future_info[future_info.size() - 1].lane_id == link_id){
-										if (future_info[future_info.size() - 1].distance + localmap.get_laneLength(exitLane_id) >= message["payload"]["est_paths"][i]["ds"].GetDouble()){
-											fi.distance = future_info[future_info.size() - 1].distance + localmap.get_laneLength(exitLane_id) - message["payload"]["est_paths"][i]["ds"].GetDouble();
-											fi.lane_id = exitLane_id;
-										}
-										else {
-											break;
-										}
-									} 
-									else{
-										break;
-									}
-
-								}
-
-								fi.speed = message["payload"]["est_paths"][i]["ds"].GetDouble() / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
-								fi.acceleration = (fi.speed - future_info[future_info.size() - 1].speed) / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
-
-								spdlog::debug("future path {0}: {1}, {2}, {3}, {4}", i, fi.lane_id, fi.distance, fi.speed, fi.acceleration);
-								future_info.push_back(fi);
-							}
-
-
-						}
+					/* adding checks to make sure only valid future points will be saved */
+					if (message["payload"]["est_paths"][i]["id"].GetInt() == 0){
+						spdlog::critical("the lane id in the future path of Vehicle {0} is invalid in the received update!", veh_id);
+					}
+					else if (message["payload"]["est_paths"][i]["ds"].GetDouble() < 0){
+						spdlog::critical("the distance to the end of lane in the future path of Vehicle {0} is invalid in the received update!", veh_id);
 					}
 					else{
-						spdlog::critical("a point in the future path of Vehicle {0} is not complete in the received update!", veh_id);
+
+
+						/* the future path received from CARMA Platform does not consider the stopping requirement at the stop bar.
+						*  therefore, CARMA Streets will force the stopping requirement to the vehicle's future path.
+						*  basically, if the vehicle is an EV, or and RDV without access, if the vehicle lane id in the future path is not the same as the vehicle entry lane id, the scheduling service will ignore the future points.
+						* */
+						if (future_info[future_info.size() - 1].distance >= message["payload"]["est_paths"][i]["ds"].GetDouble()){
+							fi = future_information();
+							// the unit of timestamp in here is sec with decimal places.
+							fi.timestamp = (double)message["payload"]["est_paths"][i]["ts"].GetInt64() / 1000;
+							fi.distance = future_info[future_info.size() - 1].distance - message["payload"]["est_paths"][i]["ds"].GetDouble();
+							fi.lane_id = to_string(message["payload"]["est_paths"][i]["id"].GetInt());
+							fi.speed = message["payload"]["est_paths"][i]["ds"].GetDouble() / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
+							fi.acceleration = (fi.speed - future_info[future_info.size() - 1].speed) / (fi.timestamp - future_info[future_info.size() - 1].timestamp);
+
+							spdlog::debug("future path {0}: {1}, {2}, {3}, {4}", i, fi.lane_id, fi.distance, fi.speed, fi.acceleration);
+							future_info.push_back(fi);
+						} 
+						else{
+							spdlog::info("Vehicle Class log - vehicle {0}: the lane id of the vehicle in the est_pathh has changed!", veh_id);
+							break;
+						}
+
 					}
+				}
+				else{
+					spdlog::critical("a point in the future path of Vehicle {0} is not complete in the received update!", veh_id);
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Initially, the distance object in each point in the est_path (i.e., the planned future path of the vehicle) was defined as the distance between the point and the end of the lane.

But recently, the distance object in each point in the est_paths is changed to the distance between the subject point and the previous point in the est_path. This PR applies the necessary changes on the scheduling_service to account for this recent change and read the distance information from the est_paths correctly.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
