### PR TITLE
Issue-105: scheduling_service core dump possible fix

### DIFF
--- a/scheduling_service/src/main.cpp
+++ b/scheduling_service/src/main.cpp
@@ -34,10 +34,11 @@ intersection_client localmap;
 unordered_map<string, vehicle> list_veh;
 set<string> list_veh_confirmation;
 set<string> list_veh_removal;
+std::mutex worker_mtx;
+
 
 
 void consumer_update(const char* payload){
-    
     rapidjson::Document message;
     message.SetObject();
     message.Parse(payload);
@@ -45,7 +46,8 @@ void consumer_update(const char* payload){
     /* if the received message does not have payload, it cannot be processed! */
     if (message.HasMember("payload")){
         if (message["payload"].HasMember("v_id")){
-            string veh_id = message["payload"]["v_id"].GetString();
+
+            string veh_id = message["payload"]["v_id"].GetString(); 
 
             /* check if the vehicle is included in the list_veh. if not, include it. */
             if (!list_veh.count(veh_id)){
@@ -84,8 +86,9 @@ void consumer_update(const char* payload){
 }
 
 rapidjson::Value scheduling_func(unordered_map<string, vehicle> list_veh, Document::AllocatorType& allocator, std::unique_ptr<csv_logger> &logger, double &last_schedule){
-
+    std::unique_lock<std::mutex> lck(worker_mtx);
     scheduling schedule(list_veh, list_veh_confirmation, localmap, config, list_veh_removal);
+    lck.unlock();
     if ( config.isScheduleLoggerEnabled() ) {
         logger->log_line( schedule.toCSV() ); 
     }
@@ -454,15 +457,15 @@ void call_consumer_thread()
         
         while (consumer_worker->is_running()) 
         {
-            
             /* remove those vehicles with old updates */
             if (list_veh_removal.size() > 0){
                 for (auto veh_id : list_veh_removal){
                     list_veh.erase(veh_id);
                 }
+                std::unique_lock<std::mutex> lck(worker_mtx);
                 list_veh_removal.clear();
+                lck.unlock();
             } 
-
             const std::string payload = consumer_worker->consume(1000);
 
             if(payload.length() > 0)
@@ -517,9 +520,7 @@ void call_scheduling_thread(){
 
                 auto t = system_clock::now() + milliseconds(int(config.get_schedulingDelta()*1000));
 
-                // copy list_veh
                 unordered_map<string, vehicle> list_veh_copy = list_veh;
-
                 // Create scheduling JSON
                 //  
                 //    {
@@ -531,6 +532,7 @@ void call_scheduling_thread(){
                 //     }
                 Document document;
                 document.SetObject();
+
                 Document::AllocatorType &allocator = document.GetAllocator();
 
                 Value metadata(kObjectType);
@@ -574,12 +576,10 @@ void call_scheduling_thread(){
 
 }
 
-
 int main(int argc,char** argv)
 {
     QCoreApplication a(argc, argv);
     localmap.call();
-
     boost::thread consumer{call_consumer_thread};
     boost::thread scheduling{call_scheduling_thread};
     consumer.join();


### PR DESCRIPTION
+ Added lock for modifying list_veh_removal list inside scheduling and
consumer thread.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Make list_veh_removal  thread safe using mutex locks.
<!--- Describe your changes in detail -->

## Related Issue
#105
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in lab with multiple runs and no memory core dump
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
