### PR TITLE
Issue-133:Loglevel fix

### DIFF
--- a/streets_utils/streets_service_base/include/streets_configuration.h
+++ b/streets_utils/streets_service_base/include/streets_configuration.h
@@ -89,8 +89,14 @@ namespace streets_service {
             rapidjson::Document parse_configuration_file();
             /**
              * @brief Update configuration parameters using json Document.
+             * @param doc rapidjson::Document containing parsed manifest.json file.
              */ 
             void update_configuration(const rapidjson::Document &doc);
+            /**
+             * @brief Update loglevel for logger using json Document
+             * @param doc rapidjson::Document containing parsed manifest.json file.
+             */ 
+            void update_log_level( const rapidjson::Document &doc );
             /**
              * @brief Helper method that reads the configurations array inside the manifest.json configuration
              * file.

--- a/streets_utils/streets_service_base/src/streets_configuration.cpp
+++ b/streets_utils/streets_service_base/src/streets_configuration.cpp
@@ -5,8 +5,13 @@ namespace streets_service {
     // Constructor
     streets_configuration::streets_configuration( const std::string &filepath ): filepath(filepath){
         SPDLOG_INFO("Printing Configuration Parameters ---------------------------------------");
+        // Parse manifest.json configuration file into rapidjson::Document
         rapidjson::Document doc = parse_configuration_file();
+        // Use service level configuration parameters from Document (i.e. loglevel and service_name)
+        // to configure spdlog default logger (terminal and file sinks)
         configure_logger(doc);
+        // Use configurations array to populate configuration map with service specific configuration
+        // parameters from Document
         update_configuration(doc);
         for(const auto& conf : configuration_map)
         {
@@ -199,12 +204,16 @@ namespace streets_service {
 
     void streets_configuration::check_update() {
         try {
+            // Check last write time of manifest.json configuration file to see if updates have been made
             std::time_t time = boost::filesystem::last_write_time(filepath);
             SPDLOG_DEBUG("Last Modified Time {0} vs Stored Last Modified Time {1}", time, last_modified);
             if ( time > last_modified) {
+                // If updates have been made parse manifest.json into Document and update loglevel and 
+                // any changed configuration parameters.
                 rapidjson::Document doc = parse_configuration_file();
                 update_log_level(doc);
                 update_configuration(doc);
+                // Set new update time to the last update read
                 last_modified = time;
             }
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This fix is a change to the streets_service_base library. It is an update that allows the streets_configuration singleton to update `loglevel` configuration parameter when changes are made to the manifest.json file while the carma-streets service is still running.
<!--- Describe your changes in detail -->

## Related Issue
#133 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Allows for real-time loglevel adjustment with service restarts
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
