### PR TITLE
Extract phase id from signal group

### DIFF
--- a/tsc_client_service/CMakeLists.txt
+++ b/tsc_client_service/CMakeLists.txt
@@ -14,7 +14,8 @@ find_library(NETSNMP "netsnmp")
 add_library(${PROJECT_NAME}_lib
         src/exceptions/spat_worker_exception.cpp
         src/snmp_client.cpp
-        src/spat_worker.cpp)
+        src/spat_worker.cpp
+        src/monitor_tsc_state.cpp)
 
 add_executable( ${PROJECT_NAME} 
         src/main.cpp)

--- a/tsc_client_service/include/monitor_tsc_state.h
+++ b/tsc_client_service/include/monitor_tsc_state.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "snmp_client.h"
+
+namespace traffic_signal_controller_service
+{
+    class tsc_state
+    {
+        private:
+        
+        std::shared_ptr<snmp_client> snmp_client_worker_;
+
+        /* Map between phase numbers(key) and signal group ids(value) for all vehicle phases in the Traffic Signal Controller*/
+        std::unordered_map<int,int> phase_num_map_;
+
+        /* Map between signal group ids(key) and phase numbers(value) for all vehicle phases in the Traffic Signal Controller*/
+        std::unordered_map<int,int> signal_group_map_;
+
+        public:
+        /** 
+         * @brief Constructor for the tsc_state class 
+         * @param snmp_client A pointer to an snmp_client worker with a connection established to a traffic signal controller
+        **/
+        tsc_state(std::shared_ptr<snmp_client> snmp_client);
+
+        /** 
+         * @brief Returns maximum channels for the traffic signal controller
+        **/
+        int get_max_channels();
+        
+        /** @brief Returns a vector of channels associated with a vehicle phase. Ignores pedestrian phase, overlap, ped Overlap, queueJump and other (types defined in NTCIP1202 v03)
+        **  @param max_channels The maximum number of channels in the traffic signal controller.
+        **/
+        std::vector<int> get_vehicle_phase_channels(int max_channels);
+
+        /** @brief Constructs a map between phase number and signal group ids
+        ** @param vehicle_phase_channels a vector of channel numbers in the traffic signal controller associated with a vehicle phase
+        * According to the NTCIP 1202 v03 documentation signal group ids in the SPAT message are the channel numbers in the TSC
+        * **/
+        void map_phase_and_signalgroup(const std::vector<int>& vehicle_phase_channels);
+
+    };
+}

--- a/tsc_client_service/include/monitor_tsc_state.h
+++ b/tsc_client_service/include/monitor_tsc_state.h
@@ -24,12 +24,14 @@ namespace traffic_signal_controller_service
         tsc_state(std::shared_ptr<snmp_client> snmp_client);
 
         /** 
-         * @brief Returns maximum channels for the traffic signal controller
+         * @brief Method for getting maximum channels for the traffic signal controller
+         * @return number of maximum channels in the traffic signal controller
         **/
         int get_max_channels();
         
         /** @brief Returns a vector of channels associated with a vehicle phase. Ignores pedestrian phase, overlap, ped Overlap, queueJump and other (types defined in NTCIP1202 v03)
         **  @param max_channels The maximum number of channels in the traffic signal controller.
+        **  @return a vector of active vehicle phases associated with a channel
         **/
         std::vector<int> get_vehicle_phase_channels(int max_channels);
 

--- a/tsc_client_service/include/monitor_tsc_state.h
+++ b/tsc_client_service/include/monitor_tsc_state.h
@@ -7,13 +7,13 @@ namespace traffic_signal_controller_service
     class tsc_state
     {
         private:
-        
+        /* A local pointer to an snmp_client object to be used through the tsc_state*/
         std::shared_ptr<snmp_client> snmp_client_worker_;
 
-        /* Map between phase numbers(key) and signal group ids(value) for all vehicle phases in the Traffic Signal Controller*/
+        /* Map between phase numbers(key) and signal group ids(value) for all active vehicle phases in the Traffic Signal Controller*/
         std::unordered_map<int,int> phase_num_map_;
 
-        /* Map between signal group ids(key) and phase numbers(value) for all vehicle phases in the Traffic Signal Controller*/
+        /* Map between signal group ids(key) and phase numbers(value) for all active vehicle phases in the Traffic Signal Controller*/
         std::unordered_map<int,int> signal_group_map_;
 
         public:

--- a/tsc_client_service/include/monitor_tsc_state.h
+++ b/tsc_client_service/include/monitor_tsc_state.h
@@ -21,19 +21,19 @@ namespace traffic_signal_controller_service
          * @brief Constructor for the tsc_state class 
          * @param snmp_client A pointer to an snmp_client worker with a connection established to a traffic signal controller
         **/
-        tsc_state(std::shared_ptr<snmp_client> snmp_client);
+        explicit tsc_state(std::shared_ptr<snmp_client> snmp_client);
 
         /** 
          * @brief Method for getting maximum channels for the traffic signal controller
          * @return number of maximum channels in the traffic signal controller
         **/
-        int get_max_channels();
+        int get_max_channels() const;
         
         /** @brief Returns a vector of channels associated with a vehicle phase. Ignores pedestrian phase, overlap, ped Overlap, queueJump and other (types defined in NTCIP1202 v03)
         **  @param max_channels The maximum number of channels in the traffic signal controller.
         **  @return a vector of active vehicle phases associated with a channel
         **/
-        std::vector<int> get_vehicle_phase_channels(int max_channels);
+        std::vector<int> get_vehicle_phase_channels(int max_channels) const;
 
         /** @brief Constructs a map between phase number and signal group ids
         ** @param vehicle_phase_channels a vector of channel numbers in the traffic signal controller associated with a vehicle phase

--- a/tsc_client_service/include/ntcip_oids.h
+++ b/tsc_client_service/include/ntcip_oids.h
@@ -14,7 +14,7 @@ namespace ntcip_oids {
     /**
      * @brief OID for MAX_CHANNELS: The maximum number of channels this TSC supports. 
     */
-    static const std::string MAX_CHANNELS = "1.3.6.1.4.1.1206.4.2.1.8.1";
+    static const std::string MAX_CHANNELS = "1.3.6.1.4.1.1206.4.2.1.8.1.0";
 
     /**
      * @brief OID for Channel control type: Used with (.channel number)

--- a/tsc_client_service/include/ntcip_oids.h
+++ b/tsc_client_service/include/ntcip_oids.h
@@ -10,6 +10,30 @@ namespace ntcip_oids {
      * @brief OID for ENABLE_SPAT
      */
     static const std::string ENABLE_SPAT_OID = "1.3.6.1.4.1.1206.3.5.2.9.44.1.0";
+    
+    /**
+     * @brief OID for MAX_CHANNELS: The maximum number of channels this TSC supports. 
+    */
+    static const std::string MAX_CHANNELS = "1.3.6.1.4.1.1206.4.2.1.8.1";
 
+    /**
+     * @brief OID for Channel control type: Used with (.channel number)
+        This object defines the channel control type (Vehicle Phase,Pedestrian Phase or Overlap)
+        SYNTAX INTEGER { other (1), phaseVehicle (2), phasePedestrian (3), overlap (4), pedOverlap (5), queueJump (6) } 
+    */
+    static const std::string CHANNEL_CONTROL_TYPE_PARAMETER = "1.3.6.1.4.1.1206.4.2.1.8.2.1.3";
+
+
+    /**
+     * @brief OID for Channel control source: Used with (.channel number)
+        Value 00 = No Control (Not In Use)
+        Value 01 = Phase 01 or Overlap A
+        Value 02 = Phase 02 or Overlap B
+        ||
+        Value 15 = Phase 15 or Overlap O
+        Value 16 = Phase 16 or Overlap P
+        etc.
+    */
+    static const std::string CHANNEL_CONTROL_SOURCE_PARAMETER = "1.3.6.1.4.1.1206.4.2.1.8.2.1.2";
 
 }

--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -39,6 +39,12 @@ class snmp_client
         /*Time after which the the snmp request times out*/
         int timeout_ = 10000;
 
+        /* Map between phase numbers(key) and signal group ids(value) for all vehicle phases in the Traffic Signal Controller*/
+        std::unordered_map<int,int> phase_num_map_;
+
+        /* Map between signal group ids(key) and phase numbers(value) for all vehicle phases in the Traffic Signal Controller*/
+        std::unordered_map<int,int> signal_group_map_;
+
     public:
         /** @brief Constructor for Traffic Signal Controller Service client.
          *  Uses the arguments provided to establish an snmp connection
@@ -67,6 +73,11 @@ class snmp_client
          *  @param request_type The request type for which the error is being logged (GET/SET).
          *  @param response The snmp_pdu struct */
         void log_error(const int& status, const std::string& request_type, snmp_pdu *response);
+
+        /** @brief Constructs a map between phase number and signal group ids
+        * According to the NTCIP 1202 v03 documentation signal group ids in the SPAT message are the channel numbers in the TSC
+        * **/
+        void get_phasenum_signalgroup_map();
 
         /** @brief Destructor for client. Closes the snmp session**/
         ~snmp_client(){

--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -75,7 +75,7 @@ class snmp_client
          *  @param status The integer value corresponding to net-snmp defined errors. macros considered are STAT_SUCCESS(0) and STAT_TIMEOUT(2)
          *  @param request_type The request type for which the error is being logged (GET/SET).
          *  @param response The snmp_pdu struct */
-        void log_error(const int& status, const int& request_type, snmp_pdu *response);
+        void log_error(const int& status, const int& request_type, snmp_pdu *response) const;
 
         /** @brief Destructor for client. Closes the snmp session**/
         ~snmp_client(){

--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -8,7 +8,7 @@
 namespace traffic_signal_controller_service
 {
 
-enum request_type
+enum class request_type
 {
     GET,
     SET,
@@ -69,13 +69,13 @@ class snmp_client
          *  @param value The integer value for the object returned by reference. For "SET" it is the value to be set. 
          *  For "GET", it is the value returned for the returned object by reference.
          *  @return Integer value at the oid, returns false if value cannot be set/requested or oid doesn't have an integer value to return.*/
-        bool process_snmp_request(const std::string& input_oid, const int& request_type, int64_t& value);
+        bool process_snmp_request(const std::string& input_oid, const request_type& request_type, int64_t& value);
 
         /** @brief Finds error type from status and logs an error.
          *  @param status The integer value corresponding to net-snmp defined errors. macros considered are STAT_SUCCESS(0) and STAT_TIMEOUT(2)
          *  @param request_type The request type for which the error is being logged (GET/SET).
          *  @param response The snmp_pdu struct */
-        void log_error(const int& status, const int& request_type, snmp_pdu *response) const;
+        void log_error(const int& status, const request_type& request_type, snmp_pdu *response) const;
 
         /** @brief Destructor for client. Closes the snmp session**/
         ~snmp_client(){

--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -74,10 +74,20 @@ class snmp_client
          *  @param response The snmp_pdu struct */
         void log_error(const int& status, const std::string& request_type, snmp_pdu *response);
 
+        /** @brief Returns maximum channels for the traffic signal controller
+        **/
+        int64_t& get_max_channels();
+        
+        /** @brief Returns a vector of channels associated with a vehicle phase
+        **  @param max_channels The maximum number of channels in the traffic signal controller.
+        **/
+        std::vector<int>& get_vehicle_phase_channels(int64_t& max_channels);
+
         /** @brief Constructs a map between phase number and signal group ids
+        ** @param vehicle_phase_channels a vector of channel numbers in the traffic signal controller associated with a vehicle phase
         * According to the NTCIP 1202 v03 documentation signal group ids in the SPAT message are the channel numbers in the TSC
         * **/
-        void get_phasenum_signalgroup_map();
+        void map_phase_and_signalgroup(std::vector<int>& vehicle_phase_channels);
 
         /** @brief Destructor for client. Closes the snmp session**/
         ~snmp_client(){

--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -76,12 +76,12 @@ class snmp_client
 
         /** @brief Returns maximum channels for the traffic signal controller
         **/
-        int64_t& get_max_channels();
+        int64_t get_max_channels();
         
         /** @brief Returns a vector of channels associated with a vehicle phase
         **  @param max_channels The maximum number of channels in the traffic signal controller.
         **/
-        std::vector<int>& get_vehicle_phase_channels(int64_t& max_channels);
+        std::vector<int> get_vehicle_phase_channels(int64_t& max_channels);
 
         /** @brief Constructs a map between phase number and signal group ids
         ** @param vehicle_phase_channels a vector of channel numbers in the traffic signal controller associated with a vehicle phase

--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -7,6 +7,14 @@
 
 namespace traffic_signal_controller_service
 {
+
+enum request_type
+{
+    GET,
+    SET,
+    OTHER //Processing this request type is not a defined behavior, included for testing only
+};
+
 class snmp_client
 {
     private:
@@ -39,11 +47,6 @@ class snmp_client
         /*Time after which the the snmp request times out*/
         int timeout_ = 10000;
 
-        /* Map between phase numbers(key) and signal group ids(value) for all vehicle phases in the Traffic Signal Controller*/
-        std::unordered_map<int,int> phase_num_map_;
-
-        /* Map between signal group ids(key) and phase numbers(value) for all vehicle phases in the Traffic Signal Controller*/
-        std::unordered_map<int,int> signal_group_map_;
 
     public:
         /** @brief Constructor for Traffic Signal Controller Service client.
@@ -66,28 +69,13 @@ class snmp_client
          *  @param value The integer value for the object returned by reference. For "SET" it is the value to be set. 
          *  For "GET", it is the value returned for the returned object by reference.
          *  @return Integer value at the oid, returns false if value cannot be set/requested or oid doesn't have an integer value to return.*/
-        bool process_snmp_request(const std::string& input_oid, const std::string& request_type, int64_t& value);
+        bool process_snmp_request(const std::string& input_oid, const int& request_type, int64_t& value);
 
         /** @brief Finds error type from status and logs an error.
          *  @param status The integer value corresponding to net-snmp defined errors. macros considered are STAT_SUCCESS(0) and STAT_TIMEOUT(2)
          *  @param request_type The request type for which the error is being logged (GET/SET).
          *  @param response The snmp_pdu struct */
-        void log_error(const int& status, const std::string& request_type, snmp_pdu *response);
-
-        /** @brief Returns maximum channels for the traffic signal controller
-        **/
-        int64_t get_max_channels();
-        
-        /** @brief Returns a vector of channels associated with a vehicle phase
-        **  @param max_channels The maximum number of channels in the traffic signal controller.
-        **/
-        std::vector<int> get_vehicle_phase_channels(int64_t& max_channels);
-
-        /** @brief Constructs a map between phase number and signal group ids
-        ** @param vehicle_phase_channels a vector of channel numbers in the traffic signal controller associated with a vehicle phase
-        * According to the NTCIP 1202 v03 documentation signal group ids in the SPAT message are the channel numbers in the TSC
-        * **/
-        void map_phase_and_signalgroup(std::vector<int>& vehicle_phase_channels);
+        void log_error(const int& status, const int& request_type, snmp_pdu *response);
 
         /** @brief Destructor for client. Closes the snmp session**/
         ~snmp_client(){

--- a/tsc_client_service/src/main.cpp
+++ b/tsc_client_service/src/main.cpp
@@ -25,7 +25,7 @@ int main()
     traffic_signal_controller_service::snmp_client worker(target_ip, target_port, community, snmp_version, timeout);
     
     //enable spat udp stream on tsc
-    int request_type = traffic_signal_controller_service::request_type::SET;
+    traffic_signal_controller_service::request_type request_type = traffic_signal_controller_service::request_type::SET;
     int64_t enable_spat_value = 2;
     worker.process_snmp_request(ntcip_oids::ENABLE_SPAT_OID, request_type, enable_spat_value);
 

--- a/tsc_client_service/src/main.cpp
+++ b/tsc_client_service/src/main.cpp
@@ -25,7 +25,7 @@ int main()
     traffic_signal_controller_service::snmp_client worker(target_ip, target_port, community, snmp_version, timeout);
     
     //enable spat udp stream on tsc
-    std::string request_type = "SET";
+    int request_type = traffic_signal_controller_service::request_type::SET;
     int64_t enable_spat_value = 2;
     worker.process_snmp_request(ntcip_oids::ENABLE_SPAT_OID, request_type, enable_spat_value);
 

--- a/tsc_client_service/src/monitor_tsc_state.cpp
+++ b/tsc_client_service/src/monitor_tsc_state.cpp
@@ -3,17 +3,16 @@
 
 namespace traffic_signal_controller_service
 {
-    tsc_state::tsc_state(std::shared_ptr<snmp_client> snmp_client) 
+    tsc_state::tsc_state(std::shared_ptr<snmp_client> snmp_client) : snmp_client_worker_(snmp_client)
     {
-        snmp_client_worker_ = snmp_client;
         // Map signal group ids and phase nums
         //Get phase number given a signal group id
-        int64_t max_channels_in_tsc = get_max_channels();
+        int max_channels_in_tsc = get_max_channels();
         std::vector<int> vehicle_phase_channels = get_vehicle_phase_channels(max_channels_in_tsc);
         map_phase_and_signalgroup(vehicle_phase_channels);
     }
 
-    int tsc_state::get_max_channels(){
+    int tsc_state::get_max_channels() const {
         int request_type = request_type::GET;
         int64_t max_channels_in_tsc = 0;
 
@@ -25,7 +24,7 @@ namespace traffic_signal_controller_service
         return (int) max_channels_in_tsc;
     }
 
-    std::vector<int> tsc_state::get_vehicle_phase_channels(int max_channels){
+    std::vector<int> tsc_state::get_vehicle_phase_channels(int max_channels) const{
         std::vector<int> vehicle_phase_channels;
         // Loop through channel control types and add channels with vehicle phase to list
         int64_t vehicle_control_type  = 0;

--- a/tsc_client_service/src/monitor_tsc_state.cpp
+++ b/tsc_client_service/src/monitor_tsc_state.cpp
@@ -1,0 +1,78 @@
+#include "monitor_tsc_state.h"
+# include "ntcip_oids.h"
+
+namespace traffic_signal_controller_service
+{
+    tsc_state::tsc_state(std::shared_ptr<snmp_client> snmp_client) 
+    {
+        snmp_client_worker_ = snmp_client;
+        // Map signal group ids and phase nums
+        //Get phase number given a signal group id
+        int64_t max_channels_in_tsc = get_max_channels();
+        std::vector<int> vehicle_phase_channels = get_vehicle_phase_channels(max_channels_in_tsc);
+        map_phase_and_signalgroup(vehicle_phase_channels);
+    }
+
+    int tsc_state::get_max_channels(){
+        int request_type = request_type::GET;
+        int64_t max_channels_in_tsc = 0;
+
+        if(!snmp_client_worker_->process_snmp_request(ntcip_oids::MAX_CHANNELS, request_type, max_channels_in_tsc))
+        {
+            SPDLOG_ERROR("Failed to get max channels");
+        }
+
+        return (int) max_channels_in_tsc;
+    }
+
+    std::vector<int> tsc_state::get_vehicle_phase_channels(int max_channels){
+        std::vector<int> vehicle_phase_channels;
+        // Loop through channel control types and add channels with vehicle phase to list
+        int64_t vehicle_control_type  = 0;
+        int request_type = request_type::GET;
+        for(int channel_num = 0; channel_num < max_channels; ++channel_num)
+        {
+            std::string control_type_parameter_oid = ntcip_oids::CHANNEL_CONTROL_TYPE_PARAMETER + "." + std::to_string(channel_num);
+
+            if(!snmp_client_worker_->process_snmp_request(control_type_parameter_oid, request_type, vehicle_control_type))
+            {
+                SPDLOG_ERROR("Failed to get channel control type");
+            }
+            
+            if(vehicle_control_type == 2)
+            {
+                vehicle_phase_channels.push_back(channel_num);
+            }
+
+        }
+
+        if(vehicle_phase_channels.empty()){
+            SPDLOG_WARN("Found no active vehicle phases");
+        }
+
+        return vehicle_phase_channels;
+    }
+
+    void tsc_state::map_phase_and_signalgroup(const std::vector<int>& vehicle_phase_channels)
+    {
+        // According to NTCIP 1202 v03 documentation Signal Group ID in a SPAT message is the Channel Number from TSC
+
+        // Get phases associated with vehicle phase channels
+        int request_type = request_type::GET;
+        for(int channel : vehicle_phase_channels)
+        {
+            int64_t phase_num = 0;
+            std::string control_source_parameter_oid = ntcip_oids::CHANNEL_CONTROL_SOURCE_PARAMETER + "." + std::to_string(channel);
+            snmp_client_worker_->process_snmp_request(control_source_parameter_oid, request_type, phase_num);
+
+            // According to NTCIP 1202 v03 returned value of 0 here would mean a phase is not associated with the channel
+            if(phase_num != 0)
+            {
+                phase_num_map_.insert(std::make_pair(channel, phase_num));
+                signal_group_map_.insert(std::make_pair(phase_num, channel));
+                SPDLOG_DEBUG("Found mapping between signal group: {0}", channel, " and phase num: {1}", phase_num );
+            }
+        }
+        
+    }
+}

--- a/tsc_client_service/src/monitor_tsc_state.cpp
+++ b/tsc_client_service/src/monitor_tsc_state.cpp
@@ -13,7 +13,7 @@ namespace traffic_signal_controller_service
     }
 
     int tsc_state::get_max_channels() const {
-        int request_type = request_type::GET;
+        request_type request_type = request_type::GET;
         int64_t max_channels_in_tsc = 0;
 
         if(!snmp_client_worker_->process_snmp_request(ntcip_oids::MAX_CHANNELS, request_type, max_channels_in_tsc))
@@ -28,7 +28,7 @@ namespace traffic_signal_controller_service
         std::vector<int> vehicle_phase_channels;
         // Loop through channel control types and add channels with vehicle phase to list
         int64_t vehicle_control_type  = 0;
-        int request_type = request_type::GET;
+        request_type request_type = request_type::GET;
         for(int channel_num = 0; channel_num < max_channels; ++channel_num)
         {
             std::string control_type_parameter_oid = ntcip_oids::CHANNEL_CONTROL_TYPE_PARAMETER + "." + std::to_string(channel_num);
@@ -57,7 +57,7 @@ namespace traffic_signal_controller_service
         // According to NTCIP 1202 v03 documentation Signal Group ID in a SPAT message is the Channel Number from TSC
 
         // Get phases associated with vehicle phase channels
-        int request_type = request_type::GET;
+        request_type request_type = request_type::GET;
         for(int channel : vehicle_phase_channels)
         {
             int64_t phase_num = 0;

--- a/tsc_client_service/src/snmp_client.cpp
+++ b/tsc_client_service/src/snmp_client.cpp
@@ -51,7 +51,7 @@ snmp_client::snmp_client(const std::string& ip, const int& port, const std::stri
 
 }
 
-bool snmp_client::process_snmp_request(const std::string& input_oid, const int& request_type, int64_t& value){
+bool snmp_client::process_snmp_request(const std::string& input_oid, const request_type& request_type, int64_t& value){
 
     /*Structure to hold response from the remote host*/
     snmp_pdu *response;
@@ -146,7 +146,7 @@ bool snmp_client::process_snmp_request(const std::string& input_oid, const int& 
 }
 
 
-void snmp_client::log_error(const int& status, const int& request_type, snmp_pdu *response) const
+void snmp_client::log_error(const int& status, const request_type& request_type, snmp_pdu *response) const
 {
 
     if (status == STAT_SUCCESS)
@@ -159,8 +159,12 @@ void snmp_client::log_error(const int& status, const int& request_type, snmp_pdu
         SPDLOG_ERROR("Timeout, no response from server");
     }
     else{
-    
-        SPDLOG_ERROR("Unknown SNMP Error for {0}", request_type);
+        if(request_type == request_type::GET){
+            SPDLOG_ERROR("Unknown SNMP Error for {0}", "GET");
+        }
+        else if(request_type == request_type::SET){
+            SPDLOG_ERROR("Unknown SNMP Error for {0}", "SET");
+        }
     }
     
 }

--- a/tsc_client_service/src/snmp_client.cpp
+++ b/tsc_client_service/src/snmp_client.cpp
@@ -146,7 +146,7 @@ bool snmp_client::process_snmp_request(const std::string& input_oid, const int& 
 }
 
 
-void snmp_client::log_error(const int& status, const int& request_type, snmp_pdu *response)
+void snmp_client::log_error(const int& status, const int& request_type, snmp_pdu *response) const
 {
 
     if (status == STAT_SUCCESS)

--- a/tsc_client_service/src/snmp_client.cpp
+++ b/tsc_client_service/src/snmp_client.cpp
@@ -51,9 +51,9 @@ snmp_client::snmp_client(const std::string& ip, const int& port, const std::stri
     // Map signal group ids and phase nums
     //Get phase number given a signal group id
     
-    int64_t max_channels_in_tsc = get_max_channels();
-    std::vector<int> vehicle_phase_channels = get_vehicle_phase_channels(max_channels_in_tsc);
-    map_phase_and_signalgroup(vehicle_phase_channels);
+    // int64_t max_channels_in_tsc = get_max_channels();
+    // std::vector<int> vehicle_phase_channels = get_vehicle_phase_channels(max_channels_in_tsc);
+    // map_phase_and_signalgroup(vehicle_phase_channels);
 
 }
 
@@ -171,21 +171,19 @@ void snmp_client::log_error(const int& status, const std::string& request_type, 
     
 }
 
-int64_t& snmp_client::get_max_channels(){
+int64_t snmp_client::get_max_channels(){
     std::string request_type = "GET";
     int64_t max_channels_in_tsc = 0;
 
-    try{
-        process_snmp_request(ntcip_oids::MAX_CHANNELS, request_type, max_channels_in_tsc);
-    }
-    catch ( const traffic_signal_controller_service::spat_worker_exception &e) {
-        SPDLOG_ERROR("Failed to get max channels : {0} ", e.what());
+    if(!process_snmp_request(ntcip_oids::MAX_CHANNELS, request_type, max_channels_in_tsc))
+    {
+        SPDLOG_ERROR("Failed to get max channels");
     }
 
     return max_channels_in_tsc;
 }
 
-std::vector<int>& snmp_client::get_vehicle_phase_channels(int64_t& max_channels){
+std::vector<int> snmp_client::get_vehicle_phase_channels(int64_t& max_channels){
     std::vector<int> vehicle_phase_channels;
     // Loop through channel control types and add channels with vehicle phase to list
     int64_t vehicle_control_type  = 0;
@@ -194,11 +192,9 @@ std::vector<int>& snmp_client::get_vehicle_phase_channels(int64_t& max_channels)
     {
         std::string control_type_parameter_oid = ntcip_oids::CHANNEL_CONTROL_TYPE_PARAMETER + "." + std::to_string(channel_num);
 
-        try{
-            process_snmp_request(control_type_parameter_oid, request_type, vehicle_control_type);
-        }
-        catch ( const traffic_signal_controller_service::spat_worker_exception &e) {
-            SPDLOG_ERROR("Failed to get channel control type : {0} ", e.what());
+        if(!process_snmp_request(control_type_parameter_oid, request_type, vehicle_control_type))
+        {
+            SPDLOG_ERROR("Failed to get channel control type");
         }
         
         if(vehicle_control_type == 2)

--- a/tsc_client_service/src/snmp_client.cpp
+++ b/tsc_client_service/src/snmp_client.cpp
@@ -50,10 +50,9 @@ snmp_client::snmp_client(const std::string& ip, const int& port, const std::stri
     
     // Map signal group ids and phase nums
     //Get phase number given a signal group id
-    
-    // int64_t max_channels_in_tsc = get_max_channels();
-    // std::vector<int> vehicle_phase_channels = get_vehicle_phase_channels(max_channels_in_tsc);
-    // map_phase_and_signalgroup(vehicle_phase_channels);
+    int64_t max_channels_in_tsc = get_max_channels();
+    std::vector<int> vehicle_phase_channels = get_vehicle_phase_channels(max_channels_in_tsc);
+    map_phase_and_signalgroup(vehicle_phase_channels);
 
 }
 

--- a/tsc_client_service/test/test_monitor_state.cpp
+++ b/tsc_client_service/test/test_monitor_state.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include "monitor_tsc_state.h"
+
+namespace traffic_signal_controller_service
+{
+    TEST(test_monitor_tsc_state, test_signal_group_phase_mapping)
+    {
+        std::string dummy_ip = "192.168.10.10";
+        int dummy_port = 601;
+        snmp_client client_worker(dummy_ip, dummy_port);
+
+        tsc_state worker(std::make_shared<snmp_client> (client_worker));
+        // Get Max channels
+        EXPECT_EQ(worker.get_max_channels(), 0);
+        // Get vehicle phase channels - using arbitrary max channels
+        int maximum_channels = 6;
+        EXPECT_TRUE(worker.get_vehicle_phase_channels(maximum_channels).empty());
+
+        std::vector<int> phase_channels = {1,2,3,4};
+        worker.map_phase_and_signalgroup(phase_channels);
+    }
+}

--- a/tsc_client_service/test/test_spat_receive_worker.cpp
+++ b/tsc_client_service/test/test_spat_receive_worker.cpp
@@ -19,7 +19,7 @@ namespace traffic_signal_controller_service
 
         snmp_client client(dummy_ip, dummy_port);
         
-        int request_type = request_type::SET;
+        request_type request_type = request_type::SET;
         int64_t enable_spat_value = 2;
         // Expect set to return false with invalid enable spat OID
         EXPECT_FALSE(client.process_snmp_request(ntcip_oids::ENABLE_SPAT_OID, request_type, enable_spat_value));

--- a/tsc_client_service/test/test_spat_receive_worker.cpp
+++ b/tsc_client_service/test/test_spat_receive_worker.cpp
@@ -19,7 +19,7 @@ namespace traffic_signal_controller_service
 
         snmp_client client(dummy_ip, dummy_port);
         
-        std::string request_type = "SET";
+        int request_type = request_type::SET;
         int64_t enable_spat_value = 2;
         // Expect set to return false with invalid enable spat OID
         EXPECT_FALSE(client.process_snmp_request(ntcip_oids::ENABLE_SPAT_OID, request_type, enable_spat_value));
@@ -32,7 +32,7 @@ namespace traffic_signal_controller_service
     {
         std::string tsc_ip_bad = "192.168.120.51";
         int tsc_port = 6053;
-        int tsc_timeout = 10;
+        int tsc_timeout = 3;
 
         spat_worker worker(tsc_ip_bad, tsc_port, tsc_timeout);
         try{
@@ -49,14 +49,14 @@ namespace traffic_signal_controller_service
     }
     /**
      * @brief Ttest UDP socket timeout parameter. Test should timeout
-     * after 5 seconds of not receiving data
+     * after 2 seconds of not receiving data
      * 
      */
     TEST(spat_receive_worker, test_create_socket_timeout)
     {
         std::string tsc_ip_bad = "127.0.0.1";
         int tsc_port = 6053;
-        int tsc_timeout = 5;
+        int tsc_timeout = 2;
 
         spat_worker worker(tsc_ip_bad, tsc_port, tsc_timeout);
 
@@ -64,7 +64,7 @@ namespace traffic_signal_controller_service
             worker.listen_udp_spat();
         }
         catch( const spat_worker_exception &e){
-            ASSERT_STREQ( e.what(), "Timeout of 5 seconds has elapsed. Closing SPaT Work UDP Socket");
+            ASSERT_STREQ( e.what(), "Timeout of 2 seconds has elapsed. Closing SPaT Work UDP Socket");
         }
         catch( ... ) {
             __assert_fail;
@@ -80,7 +80,7 @@ namespace traffic_signal_controller_service
     {
         std::string tsc_ip_bad = "asdhas.asd";
         int tsc_port = 6053;
-        int tsc_timeout = 5;
+        int tsc_timeout = 2;
 
         spat_worker worker(tsc_ip_bad, tsc_port, tsc_timeout);
         try{

--- a/tsc_client_service/test/test_traffic_signal_controller_service.cpp
+++ b/tsc_client_service/test/test_traffic_signal_controller_service.cpp
@@ -49,6 +49,16 @@ namespace traffic_signal_controller_service
         request_type = "INVALID";
         EXPECT_FALSE(worker.process_snmp_request(test_oid, request_type, set_value));
 
+        // Get Max channels
+        EXPECT_EQ(worker.get_max_channels(), 0);
+
+        // Get vehicle phase channels - using arbitrary max channels
+        int64_t maximum_channels = 6;
+        EXPECT_TRUE(worker.get_vehicle_phase_channels(maximum_channels).empty());
+
+        std::vector<int> phase_channels = {1,2,3,4};
+        worker.map_phase_and_signalgroup(phase_channels);
         
     }
+
 }

--- a/tsc_client_service/test/test_traffic_signal_controller_service.cpp
+++ b/tsc_client_service/test/test_traffic_signal_controller_service.cpp
@@ -51,7 +51,6 @@ namespace traffic_signal_controller_service
 
         // Get Max channels
         EXPECT_EQ(worker.get_max_channels(), 0);
-
         // Get vehicle phase channels - using arbitrary max channels
         int64_t maximum_channels = 6;
         EXPECT_TRUE(worker.get_vehicle_phase_channels(maximum_channels).empty());

--- a/tsc_client_service/test/test_traffic_signal_controller_service.cpp
+++ b/tsc_client_service/test/test_traffic_signal_controller_service.cpp
@@ -13,7 +13,7 @@ namespace traffic_signal_controller_service
         snmp_client worker(dummy_ip, dummy_port);
 
         // Test GET
-        int request_type = request_type::GET;
+        request_type request_type = request_type::GET;
         int64_t integer_response = 0;
         // Expect get call to fail since we're communicating with invalid host
         EXPECT_FALSE(worker.process_snmp_request(test_oid, request_type, integer_response));

--- a/tsc_client_service/test/test_traffic_signal_controller_service.cpp
+++ b/tsc_client_service/test/test_traffic_signal_controller_service.cpp
@@ -13,7 +13,7 @@ namespace traffic_signal_controller_service
         snmp_client worker(dummy_ip, dummy_port);
 
         // Test GET
-        std::string request_type = "GET";
+        int request_type = request_type::GET;
         int64_t integer_response = 0;
         // Expect get call to fail since we're communicating with invalid host
         EXPECT_FALSE(worker.process_snmp_request(test_oid, request_type, integer_response));
@@ -24,7 +24,7 @@ namespace traffic_signal_controller_service
         EXPECT_FALSE(worker.process_snmp_request(test_oid, request_type, integer_response));
 
         // Test log_error
-        request_type = "GET";
+        request_type = request_type::GET;
         snmp_pdu *response = nullptr;
         int status = STAT_TIMEOUT;
         worker.log_error(status, request_type, response);
@@ -33,30 +33,21 @@ namespace traffic_signal_controller_service
         worker.log_error(status, request_type, response);
 
         // Test SET
-        request_type = "SET";
+        request_type = request_type::SET;
         int64_t set_value = 10;
         // Expect set call to fail since we're communicating with invalid host
         EXPECT_FALSE(worker.process_snmp_request(test_oid, request_type, set_value));
 
         // Test log_error
         status = STAT_TIMEOUT;
-        request_type = "SET";
+        request_type = request_type::SET;
         
         status = -7; //Random error value
         worker.log_error(status, request_type,response);
 
         // Invalid Request type
-        request_type = "INVALID";
+        request_type = request_type::OTHER;
         EXPECT_FALSE(worker.process_snmp_request(test_oid, request_type, set_value));
-
-        // Get Max channels
-        EXPECT_EQ(worker.get_max_channels(), 0);
-        // Get vehicle phase channels - using arbitrary max channels
-        int64_t maximum_channels = 6;
-        EXPECT_TRUE(worker.get_vehicle_phase_channels(maximum_channels).empty());
-
-        std::vector<int> phase_channels = {1,2,3,4};
-        worker.map_phase_and_signalgroup(phase_channels);
         
     }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR adds a mapping between phase id and signal group id(as defined in in SPAT messages)
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
