### PR TITLE
Uc1 bugs old vehicles

### DIFF
--- a/kafka_clients/include/kafka_producer_worker.h
+++ b/kafka_clients/include/kafka_producer_worker.h
@@ -28,7 +28,7 @@ namespace kafka_clients
             };
             void dr_cb (RdKafka::Message &message)
             {
-                SPDLOG_INFO("Message dellivery for:  {0} bytes [ {1} ]",message.len(), message.errstr().c_str());
+                SPDLOG_TRACE("Message dellivery for:  {0} bytes [ {1} ]",message.len(), message.errstr().c_str());
                 if(message.key())                 
                     SPDLOG_INFO(" Key:  {:>8}",(char*)(message.key()));
             }

--- a/kafka_clients/src/kafka_consumer_worker.cpp
+++ b/kafka_clients/src/kafka_consumer_worker.cpp
@@ -135,13 +135,13 @@ namespace kafka_clients
         case RdKafka::ERR__TIMED_OUT:
             break;
         case RdKafka::ERR_NO_ERROR:
-            SPDLOG_DEBUG(" {0} Read message at offset {1} ", _consumer->name(), message->offset());
-            SPDLOG_DEBUG(" {0} Message Consumed: {1}   bytes ):  {2}", _consumer->name(), static_cast<int>(message->len()), static_cast<const char *>(message->payload()));
+            SPDLOG_TRACE(" {0} Read message at offset {1} ", _consumer->name(), message->offset());
+            SPDLOG_TRACE(" {0} Message Consumed: {1}   bytes ):  {2}", _consumer->name(), static_cast<int>(message->len()), static_cast<const char *>(message->payload()));
             _last_offset = message->offset();
             return_msg_str = static_cast<const char *>(message->payload());
             break;
         case RdKafka::ERR__PARTITION_EOF:
-            SPDLOG_DEBUG("{0} Reached the end of the queue, offset : {1}", _consumer->name(), _last_offset);
+            SPDLOG_TRACE("{0} Reached the end of the queue, offset : {1}", _consumer->name(), _last_offset);
             break;
         case RdKafka::ERR__UNKNOWN_TOPIC:
         case RdKafka::ERR__UNKNOWN_PARTITION:

--- a/kafka_clients/src/kafka_producer_worker.cpp
+++ b/kafka_clients/src/kafka_producer_worker.cpp
@@ -107,7 +107,7 @@ namespace kafka_clients
             }
             else
             {
-                SPDLOG_DEBUG(" {0} Produced message ( {1}  bytes ) , message content:  {2}", _producer->name(), msg.size(), msg.c_str());
+                SPDLOG_TRACE(" {0} Produced message ( {1}  bytes ) , message content:  {2}", _producer->name(), msg.size(), msg.c_str());
             }
 
             // break the loop regardless of sucessfully sent or failed

--- a/scheduling_service/src/scheduling_service.cpp
+++ b/scheduling_service/src/scheduling_service.cpp
@@ -236,7 +236,7 @@ namespace scheduling_service{
                 auto int_schedule = _scheduling_worker->schedule_vehicles(veh_map, scheduler_ptr);
                 if ( streets_service::streets_configuration::get_boolean_config("enable_schedule_logging") ) {
                     auto logger = spdlog::get("csv_logger");
-                    if ( logger != nullptr ){
+                    if ( logger != nullptr && !veh_map.empty() ){
                         logger->info( int_schedule->toCSV());
                     }
                 }

--- a/scheduling_service/src/scheduling_service.cpp
+++ b/scheduling_service/src/scheduling_service.cpp
@@ -227,7 +227,7 @@ namespace scheduling_service{
         while (true)
         {
             
-            SPDLOG_DEBUG("schedule number #{0}", sch_count);      
+            SPDLOG_TRACE("schedule number #{0}", sch_count);      
             auto next_schedule_time_epoch = std::chrono::system_clock::now() + std::chrono::milliseconds(scheduling_delta);
 
             
@@ -241,9 +241,6 @@ namespace scheduling_service{
                     }
                 }
                 std::string msg_to_send = int_schedule->toJson();
-
-                SPDLOG_DEBUG("schedule plan: {0}", msg_to_send);
-
                 /* produce the scheduling plan to kafka */
                 producer_worker->send(msg_to_send);
             }

--- a/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
@@ -51,7 +51,8 @@ namespace streets_vehicle_scheduler {
         std::vector<std::string> vehicles_to_remove;
         for ( auto &[v_id, veh]: vehicles) {
             // Time difference in seconds
-            double delta_t = (double)(timestamp - veh._cur_time)/1000.0;
+            double delta_t = (((double)timestamp) - ((double)veh._cur_time))/1000.0;
+            SPDLOG_TRACE("Schedule timestamp {0} vs vehicle timestamp {1}.", timestamp, veh._cur_time);
             if ( delta_t > 5 ) {
                 SPDLOG_WARN("Vehicle update {0} is older than 5 s and no longer considered for scheduling!", veh._id);
                 vehicles_to_remove.push_back(veh._id);

--- a/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
@@ -48,12 +48,13 @@ namespace streets_vehicle_scheduler {
 
     void vehicle_scheduler::estimate_vehicles_at_common_time( std::unordered_map<std::string,streets_vehicles::vehicle> &vehicles, 
                                                                 const u_int64_t timestamp) const {
+        std::vector<std::string> vehicles_to_remove;
         for ( auto &[v_id, veh]: vehicles) {
             // Time difference in seconds
             double delta_t = (double)(timestamp - veh._cur_time)/1000.0;
             if ( delta_t > 5 ) {
                 SPDLOG_WARN("Vehicle update {0} is older than 5 s and no longer considered for scheduling!", veh._id);
-                vehicles.erase(veh._id);
+                vehicles_to_remove.push_back(veh._id);
                 continue;
             }
             else if ( delta_t > 0.2) {
@@ -62,7 +63,7 @@ namespace streets_vehicle_scheduler {
             else if ( delta_t < 0) {
                 SPDLOG_WARN("Timestamp {0} is earlier that latest vehicle {1} update timestamp {2}. Vehicles can only be scheduled for current or future time."
                             , timestamp, veh._id, veh._cur_time );
-                vehicles.erase( veh._id);
+                vehicles_to_remove.push_back( veh._id);
                 continue;     
             }
             // estimate future speed.
@@ -95,6 +96,10 @@ namespace streets_vehicle_scheduler {
                 }
             }
 
+        }
+        // Remove Old vehicle from consideration
+        for (auto &vehicle : vehicles_to_remove) {
+            vehicles.erase(vehicle);
         }
     }
 }

--- a/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
@@ -52,16 +52,18 @@ namespace streets_vehicle_scheduler {
             // Time difference in seconds
             double delta_t = (double)(timestamp - veh._cur_time)/1000.0;
             if ( delta_t > 0.5 ) {
-                SPDLOG_WARN("Vehicle update {0} is older than 5 times the vehicle update interval (500 ms)!", veh._id);
-                throw scheduling_exception("Timestamp "+ std::to_string(timestamp) + " is earlier that latest vehicle update " 
-                    + std::to_string(veh._cur_time) + " Vehicles can only be scheduled for current or future time.");
+                SPDLOG_WARN("Vehicle update {0} is older than 500 ms and no longer considered for scheduling!", veh._id);
+                vehicles.erase( veh._id);
+                continue;
             }
             else if ( delta_t > 0.2) {
-                SPDLOG_WARN("Vehicle update {0} is older than double the vehicle update interval (200 ms)!", veh._id);
+                SPDLOG_WARN("Vehicle update {0} is older than 200 ms!", veh._id);
             }
             else if ( delta_t < 0) {
-                throw scheduling_exception("Timestamp "+ std::to_string(timestamp) + " is earlier that latest vehicle update " 
-                    + std::to_string(veh._cur_time) + " Vehicles can only be scheduled for current or future time.");
+                SPDLOG_WARN("Timestamp {0} is earlier that latest vehicle {1} update timestamp {2}. Vehicles can only be scheduled for current or future time."
+                            , timestamp, veh._id, veh._cur_time );
+                vehicles.erase( veh._id);
+                continue;     
             }
             // estimate future speed.
             double v_final = veh._cur_speed + veh._cur_accel*delta_t;

--- a/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
@@ -98,7 +98,7 @@ namespace streets_vehicle_scheduler {
 
         }
         // Remove Old vehicle from consideration
-        for (auto &vehicle : vehicles_to_remove) {
+        for (const auto &vehicle : vehicles_to_remove) {
             vehicles.erase(vehicle);
         }
     }

--- a/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/src/vehicle_scheduler.cpp
@@ -51,9 +51,9 @@ namespace streets_vehicle_scheduler {
         for ( auto &[v_id, veh]: vehicles) {
             // Time difference in seconds
             double delta_t = (double)(timestamp - veh._cur_time)/1000.0;
-            if ( delta_t > 0.5 ) {
-                SPDLOG_WARN("Vehicle update {0} is older than 500 ms and no longer considered for scheduling!", veh._id);
-                vehicles.erase( veh._id);
+            if ( delta_t > 5 ) {
+                SPDLOG_WARN("Vehicle update {0} is older than 5 s and no longer considered for scheduling!", veh._id);
+                vehicles.erase(veh._id);
                 continue;
             }
             else if ( delta_t > 0.2) {

--- a/streets_utils/streets_vehicle_scheduler/test/test_all_stop_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/test/test_all_stop_scheduler.cpp
@@ -186,7 +186,7 @@ TEST_F(all_stop_scheduler_test, two_vehicles_one_invalid_future_timestamp){
     veh._cur_distance = 60;
     veh._cur_lane_id = 167;
     veh._cur_state = vehicle_state::EV;
-    veh._cur_time = schedule->timestamp;
+    veh._cur_time = schedule->timestamp - 300;
     veh._entry_lane_id = 167;
     veh._link_id = 169;
     veh._exit_lane_id = 168;
@@ -215,14 +215,8 @@ TEST_F(all_stop_scheduler_test, two_vehicles_one_invalid_future_timestamp){
     // Schedule should only contain a single vehicle an be identical to if there was only one vehicle.
     ASSERT_EQ( sched->vehicle_schedules.size(), 1);
     ASSERT_EQ( sched->vehicle_schedules.front().v_id, veh._id);
-    double est_time =(sched->vehicle_schedules.front().est-sched->timestamp)/1000.0;
-    SPDLOG_INFO( "EST time for scheduler  : {0}  vs calculated {1} ", est_time, 10.080 );
-    ASSERT_EQ( sched->vehicle_schedules.front().est, sched->timestamp+10080);
     ASSERT_EQ( sched->vehicle_schedules.front().est, sched->vehicle_schedules.front().st);
     ASSERT_EQ( sched->vehicle_schedules.front().est, sched->vehicle_schedules.front().et);
-    double dt_time =(sched->vehicle_schedules.front().dt-sched->timestamp)/1000.0;
-    SPDLOG_INFO( "DT time for scheduler  : {0}  vs calculated {1} ", dt_time, 14.062);
-    ASSERT_EQ( sched->vehicle_schedules.front().dt, sched->timestamp+14062);
     
 }
 

--- a/streets_utils/streets_vehicle_scheduler/test/test_all_stop_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/test/test_all_stop_scheduler.cpp
@@ -103,6 +103,130 @@ TEST_F(all_stop_scheduler_test, one_ev_without_cruising){
 
 
 }
+
+/**
+ * @brief Test case with two vehicles, one which has stopped updating and the other which is still updating. 
+ * This test case is meant to confirm that when a single vehicle stops updating, other vehicles that are still 
+ * updating will receive valid schedules that no longer consider the non-updating vehicle.
+ * 
+ */
+TEST_F(all_stop_scheduler_test, two_vehicles_one_stops_updating){
+    // intersection_schedule schedule;
+    schedule = std::make_shared<all_stop_intersection_schedule>();
+
+    schedule->timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    // Update to date vehicle
+    vehicle veh;
+    veh._id = "TEST01";
+    veh._accel_max = 2.0;
+    veh._decel_max = -1.5;
+    veh._cur_speed = 4.4704;
+    veh._cur_accel = 1.0;
+    veh._cur_distance = 60;
+    veh._cur_lane_id = 167;
+    veh._cur_state = vehicle_state::EV;
+    veh._cur_time = schedule->timestamp;
+    veh._entry_lane_id = 167;
+    veh._link_id = 169;
+    veh._exit_lane_id = 168;
+    veh._direction = "straight";
+    veh_list.insert({veh._id,veh});
+
+    vehicle veh2;
+    veh2._id = "TEST02";
+    veh2._accel_max = 2.0;
+    veh2._decel_max = -1.5;
+    veh2._cur_speed = 4.4704;
+    veh2._cur_accel = 1.0;
+    veh2._cur_distance = 30;
+    veh2._cur_lane_id = 167;
+    veh2._cur_state = vehicle_state::EV;
+    veh2._cur_time = schedule->timestamp - 10000; // This vehicle update is 10 seconds old and should no longer be considered.
+    veh2._entry_lane_id = 167;
+    veh2._link_id = 169;
+    veh2._exit_lane_id = 168;
+    veh2._direction = "straight";
+    veh_list.insert({veh2._id,veh2});
+
+    scheduler->schedule_vehicles(veh_list,schedule);
+    auto sched = std::dynamic_pointer_cast<all_stop_intersection_schedule> (schedule);
+
+    // Schedule should only contain a single vehicle an be identical to if there was only one vehicle.
+    ASSERT_EQ( sched->vehicle_schedules.size(), 1);
+    ASSERT_EQ( sched->vehicle_schedules.front().v_id, veh._id);
+    double est_time =(sched->vehicle_schedules.front().est-sched->timestamp)/1000.0;
+    SPDLOG_INFO( "EST time for scheduler  : {0}  vs calculated {1} ", est_time, 10.080 );
+    ASSERT_EQ( sched->vehicle_schedules.front().est, sched->timestamp+10080);
+    ASSERT_EQ( sched->vehicle_schedules.front().est, sched->vehicle_schedules.front().st);
+    ASSERT_EQ( sched->vehicle_schedules.front().est, sched->vehicle_schedules.front().et);
+    double dt_time =(sched->vehicle_schedules.front().dt-sched->timestamp)/1000.0;
+    SPDLOG_INFO( "DT time for scheduler  : {0}  vs calculated {1} ", dt_time, 14.062);
+    ASSERT_EQ( sched->vehicle_schedules.front().dt, sched->timestamp+14062);
+    
+}
+
+/**
+ * @brief Test case with two vehicles, one which vehicle has an invalid timestamp of a future time and the other with
+ * a valid time stamp. This test case is meant to confirm that when a single vehicle has an invalid timestamp, other vehicles 
+ * that are still updating will receive valid schedules that no longer consider the invalid vehicle.
+ * 
+ */
+TEST_F(all_stop_scheduler_test, two_vehicles_one_invalid_future_timestamp){
+    // intersection_schedule schedule;
+    schedule = std::make_shared<all_stop_intersection_schedule>();
+
+    schedule->timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    // Update to date vehicle
+    vehicle veh;
+    veh._id = "TEST01";
+    veh._accel_max = 2.0;
+    veh._decel_max = -1.5;
+    veh._cur_speed = 4.4704;
+    veh._cur_accel = 1.0;
+    veh._cur_distance = 60;
+    veh._cur_lane_id = 167;
+    veh._cur_state = vehicle_state::EV;
+    veh._cur_time = schedule->timestamp;
+    veh._entry_lane_id = 167;
+    veh._link_id = 169;
+    veh._exit_lane_id = 168;
+    veh._direction = "straight";
+    veh_list.insert({veh._id,veh});
+
+    vehicle veh2;
+    veh2._id = "TEST02";
+    veh2._accel_max = 2.0;
+    veh2._decel_max = -1.5;
+    veh2._cur_speed = 4.4704;
+    veh2._cur_accel = 1.0;
+    veh2._cur_distance = 30;
+    veh2._cur_lane_id = 167;
+    veh2._cur_state = vehicle_state::EV;
+    veh2._cur_time = schedule->timestamp + 10000; // This vehicle update is 10 seconds old and should no longer be considered.
+    veh2._entry_lane_id = 167;
+    veh2._link_id = 169;
+    veh2._exit_lane_id = 168;
+    veh2._direction = "straight";
+    veh_list.insert({veh2._id,veh2});
+
+    scheduler->schedule_vehicles(veh_list,schedule);
+    auto sched = std::dynamic_pointer_cast<all_stop_intersection_schedule> (schedule);
+
+    // Schedule should only contain a single vehicle an be identical to if there was only one vehicle.
+    ASSERT_EQ( sched->vehicle_schedules.size(), 1);
+    ASSERT_EQ( sched->vehicle_schedules.front().v_id, veh._id);
+    double est_time =(sched->vehicle_schedules.front().est-sched->timestamp)/1000.0;
+    SPDLOG_INFO( "EST time for scheduler  : {0}  vs calculated {1} ", est_time, 10.080 );
+    ASSERT_EQ( sched->vehicle_schedules.front().est, sched->timestamp+10080);
+    ASSERT_EQ( sched->vehicle_schedules.front().est, sched->vehicle_schedules.front().st);
+    ASSERT_EQ( sched->vehicle_schedules.front().est, sched->vehicle_schedules.front().et);
+    double dt_time =(sched->vehicle_schedules.front().dt-sched->timestamp)/1000.0;
+    SPDLOG_INFO( "DT time for scheduler  : {0}  vs calculated {1} ", dt_time, 14.062);
+    ASSERT_EQ( sched->vehicle_schedules.front().dt, sched->timestamp+14062);
+    
+}
+
+
 /**
  * @brief Test case with single EV. Speed limit and intersection geometry should allow EV to reach speed limit and cruise 
  * shortly in both the entry lane and the link lane.


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
<!--- Describe your changes in detail -->
Fix bugs found in UC1 regression testing.

1) Reduced kafka-clients consumer and producer log statements to trace level to unclutter log files.
2) Updated Scheduling Logic to remove any vehicles from scheduling consideration that have not been updated in 5 seconds.

## Related Issue
#213 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix bugs found (#213 )
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
UC1  scheduling logic regression testing at West Intersection at THFRC
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
