### PR TITLE
Issue-206: Add correlation threshold config param

### DIFF
--- a/intersection_model/include/intersection_model.h
+++ b/intersection_model/include/intersection_model.h
@@ -215,9 +215,12 @@ namespace intersection_model
             /***
              * @brief Update intersection info structure with incoming map msg consumed by kafka map consumer
              * @param intersection_map populated with MAP message published by v2xhub. This map message describes intersection geometry and signal group ids
+             * @param lane_to_lanelet_corr_thres The lane (MAP) to lanelet (lanelet2 map) correlation threshold in meters. 
+             * If the average distance between nodes in a lane of the MAP and the centerline of the any existing intersection 
+             * lanelet described in the lanelet2 map exceeds lanewidth plus this threshold they will not correlate.
              * @return True if the intersection info is updated, otherwise false
              **/
-            bool update_intersecion_info_by_map_msg(const std::shared_ptr<intersection_map> int_map_msg);
+            bool update_intersecion_info_by_map_msg(const std::shared_ptr<intersection_map> int_map_msg, const double lane_to_lanelet_corr_thres);
             /**
              * @brief Comparing the geometry between lane in the MAP message and geometry of the list of lanelets to determine which lanelet this lane path fall into.
              * @param ref_point Reference location (latitude, longitude, elevation) of the subsequent data points
@@ -225,8 +228,16 @@ namespace intersection_model
              * @param lane_width MAP message lane definition includes the lane width.
              * @param subj_lanelets List of lanelets
              * @param lane2lanelet_m A mapping reference to update with lane id and its relevant lanelet id
+             * @param lane_to_lanelet_corr_thres The lane (MAP) to lanelet (lanelet2 map) correlation threshold in meters. 
+             * If the average distance between nodes in a lane of the MAP and the centerline of the any existing intersection 
+             * lanelet described in the lanelet2 map exceeds lanewidth plus this threshold they will not correlate.
              */
-            void mapping_lane_id_2_lanelet_id(const map_referencepoint& ref_point, const map_lane& lane, const long lane_width, const std::vector<lanelet::ConstLanelet>& subj_lanelets, std::unordered_map<long,lanelet::ConstLanelet>& lane2lanelet_m) const;
+            void mapping_lane_id_2_lanelet_id(const map_referencepoint& ref_point, 
+                                                const map_lane& lane, 
+                                                const long lane_width, 
+                                                const std::vector<lanelet::ConstLanelet>& subj_lanelets, 
+                                                std::unordered_map<long,lanelet::ConstLanelet>& lane2lanelet_m,
+                                                const double lane_to_lanelet_corr_thres) const;
 
             /**
              * @brief Convert the centerline geometry of lane defined in J2735 MAP to a list of lanelet2 points in the OSM map.
@@ -298,9 +309,6 @@ namespace intersection_model
             double participantHeight            = 2.;
             double minLaneChangeLength          = 0.;
             int projector_type                  = 0;
-            const char* osm_file_path_key       = "osm_file_path";      //The osm_file_path should match configuration name in the manifest.json
-            const char* intersection_name_key   = "intersection_name";  //The intersection_name should match configuration name in the manifest.json
-            const char* intersection_id_key     = "intersection_id";    //The intersection_id should match configuration name in the manifest.json
             const double MPH_TO_MS              = 0.44704;              //Miles per hour to meters per seconds conversion
             const double CM_TO_M                = 0.01;                 //Centimiter to meter conversion
             const double DM_TO_M                = 0.1;                  //Decimeter to meter conversion

--- a/intersection_model/manifest.json
+++ b/intersection_model/manifest.json
@@ -21,6 +21,12 @@
             "type": "INTEGER"
         },
         {
+            "name": "lane_to_lanelet_corr_thres",
+            "value": 7.5,
+            "description": "The lane (MAP) to lanelet (lanelet2 map) correlation threshold in meters. If the average distance between nodes in a lane of the MAP and the centerline of the any existing intersection lanelet described in the lanelet2 map exceeds lanewidth plus this threshold they will not correlate.",
+            "type":"DOUBLE"
+        },
+        {
             "name": "host_address",
             "value": "127.0.0.1",
             "description": "Address to host intersection model REST server.",

--- a/intersection_model/src/server/src/main.cpp
+++ b/intersection_model/src/server/src/main.cpp
@@ -69,7 +69,7 @@ void intersection_model_event_update(std::shared_ptr<intersection_model::interse
                 if(is_updated)
                 {
                     auto map_msg_ptr = map_msp_worker->get_map_msg_ptr(); 
-                    model->update_intersecion_info_by_map_msg(map_msg_ptr, lane_to_lanelet_corr_thres);
+                    model->update_intersecion_info_by_map_msg(map_msg_ptr, lane_2_lanelet_corr_thres);
                 }
             }
         }

--- a/intersection_model/src/server/src/main.cpp
+++ b/intersection_model/src/server/src/main.cpp
@@ -51,7 +51,9 @@ void catchUnixSignals(QList<int> quitSignals) {
 }
 #endif
 
-void intersection_model_event_update(std::shared_ptr<intersection_model::intersection_model> model, std::shared_ptr<intersection_model::map_msg_worker> map_msp_worker)
+void intersection_model_event_update(std::shared_ptr<intersection_model::intersection_model> model, 
+                                    std::shared_ptr<intersection_model::map_msg_worker> map_msp_worker, 
+                                    const double lane_2_lanelet_corr_thres)
 {
     auto _map_msg_consumer = map_msp_worker->get_map_msg_consumer_ptr();
     if (map_msp_worker && _map_msg_consumer)
@@ -67,7 +69,7 @@ void intersection_model_event_update(std::shared_ptr<intersection_model::interse
                 if(is_updated)
                 {
                     auto map_msg_ptr = map_msp_worker->get_map_msg_ptr(); 
-                    model->update_intersecion_info_by_map_msg(map_msg_ptr);
+                    model->update_intersecion_info_by_map_msg(map_msg_ptr, lane_to_lanelet_corr_thres);
                 }
             }
         }
@@ -116,7 +118,11 @@ int main(int argc, char *argv[])
                                                                                 streets_service::streets_configuration::get_string_config("bootstrap_server"),
                                                                                 streets_service::streets_configuration::get_string_config("map_msg_group_id"),
                                                                                 streets_service::streets_configuration::get_string_config("map_msg_topic"));
-    std::thread intersection_model_events_thread(intersection_model_event_update, std::ref(model), std::ref(map_msp_worker));
+    // Get Lane to lanelet correlation threshold.The lane (MAP) to lanelet (lanelet2 map) correlation threshold in meters. 
+    // If the average distance between nodes in a lane of the MAP and the centerline of the any existing intersection lanelet 
+    // described in the lanelet2 map exceeds lanewidth plus this threshold they will not correlate.
+    double lane_2_lanelet_corr_thres = streets_service::streets_configuration::get_double_config("lane_to_lanelet_corr_thres");
+    std::thread intersection_model_events_thread(intersection_model_event_update, std::ref(model), std::ref(map_msp_worker), lane_2_lanelet_corr_thres);
     intersection_model_events_thread.detach();
 
     return a.exec();

--- a/intersection_model/test/test_intersection_model.cpp
+++ b/intersection_model/test/test_intersection_model.cpp
@@ -287,7 +287,7 @@ TEST(intersection_model_test, update_intersecion_info_by_map_msg)
     intersection_model::intersection_model model;
     model.read_lanelet2_map("../../sample_map/town01_vector_map_test.osm");
     ASSERT_TRUE(model.update_intersection_info());
-    model.update_intersecion_info_by_map_msg(int_map_msg_ptr);
+    model.update_intersecion_info_by_map_msg(int_map_msg_ptr, 0.0);
     for(auto link_lane: model.get_intersection_info().link_lanelets_info)
     {
         switch (link_lane.id)

--- a/intersection_model/test/test_intersection_model.cpp
+++ b/intersection_model/test/test_intersection_model.cpp
@@ -358,7 +358,7 @@ TEST(intersection_model_test, mapping_lane_id_2_lanelet_id)
     std::vector<lanelet::ConstLanelet>  enter_ll_v;
     enter_ll_v.push_back(enter_ll);
     std::unordered_map<long, lanelet::ConstLanelet> lane2lanelet_m;
-    model.mapping_lane_id_2_lanelet_id(ref_point,lane2,cur_geometry.approach.width, enter_ll_v,lane2lanelet_m);
+    model.mapping_lane_id_2_lanelet_id(ref_point,lane2,cur_geometry.approach.width, enter_ll_v,lane2lanelet_m, 0.0);
     ASSERT_EQ(167,lane2lanelet_m[lane2.lane_id].id());
 }
 


### PR DESCRIPTION
+ Added correlation config parameter.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Currently the intersection model will only correlate intersection lanes (entry, departure) with lanes in the J2735 MAP message (Ingress, Egress) if the average distance between the nodes in the MAP message and the center line of the lanelet in the OSM map is less than the lane width.  When one or more of these lanes do not correlate on reception of the MAP message the intersection_model terminates due to a segmentation fault. 

This PR addresses this issue by adding a `lane_to_lanelet_corr_thres` configuration parameter which acts as an addition configurable buffer to account for any discrepancy between the MAP message and the lanelet2 map. The discrepancy is likely due to the fact that the fact that the J2735 MAP message is generated using google map location data which is probably slightly less accurate than the lanelet2 map generation data. CARMA-Platform accounts for this discrepancy using offsets but this is a simpler solution that fits the requirements of CARMA-Streets **Intersection Model**.  
## Related Issue
#206 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Allow MAP and lanelet2 map correlation at the intersection model, even when there is significant discrepancy between  entry and exit lane locations . 
## How Has This Been Tested?
Tested inside **Test Intersection** environment  with West and East Intersection lanelet map and MAP messages 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
