### PR TITLE
Consume tsc config at Signal Optimization Service 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 /kafka_clients/build
 /scheduling_service/build
 /message_services/build
+/signal_opt_service/build
 /streets_utils/streets_service_base/build
 /streets_utils/streets_vehicle_list/build
 /streets_utils/streets_vehicle_scheduler/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       DOCKER_HOST_IP:  ${DOCKER_HOST_IP}
     volumes: 
       - ./intersection_model/manifest.json:/home/carma-streets/intersection_model/manifest.json
-      - ./MAP/vector_map.osm:/home/carma-streets/intersection_model/vector_map.osm
+      - ./MAP/:/home/carma-streets/intersection_model/MAP/
       - ./intersection_model/logs/:/home/carma-streets/intersection_model/logs/
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
@@ -156,7 +156,8 @@ services:
       - kafka
       - intersection_model
       - message_services
-      - scheduling_service    
+      - scheduling_service 
+      - tsc_service   
     environment:
       DOCKER_HOST_IP:  ${DOCKER_HOST_IP}
       WAIT_HOSTS: localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,6 @@ services:
     restart: always
     depends_on:
       - db
-      - kafka
     environment:
       - MYSQL_PASSWORD=/run/secrets/mysql_password
     secrets:

--- a/kafka_clients/CMakeLists.txt
+++ b/kafka_clients/CMakeLists.txt
@@ -75,4 +75,4 @@ target_include_directories(${BINARY}
                            $<INSTALL_INTERFACE:include>
                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                            PRIVATE
-                           ${CMAKE_CURRENT_SOURCE_DIR}/src})
+                           ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/kafka_clients/CMakeLists.txt
+++ b/kafka_clients/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(${PROJECT_NAME}_lib
                            PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-TARGET_LINK_LIBRARIES (${PROJECT_NAME}_lib PUBLIC Boost::system Boost::thread rdkafka++ spdlog::spdlog )
+TARGET_LINK_LIBRARIES (${PROJECT_NAME}_lib PUBLIC Boost::system Boost::thread rdkafka++ spdlog::spdlog gmock )
 
 
 #######

--- a/kafka_clients/include/kafka_consumer_worker.h
+++ b/kafka_clients/include/kafka_consumer_worker.h
@@ -137,12 +137,13 @@ namespace kafka_clients
 
         public:
             kafka_consumer_worker(const std::string &broker_str, const std::string &topic_str, const std::string & group_id, int64_t cur_offset = 0, int32_t partition = 0);
-            bool init();
-            const char* consume(int timeout_ms);
-            void subscribe();
-            void stop();
-            void printCurrConf();
-            bool is_running() const;
+            virtual bool init();
+            virtual const char* consume(int timeout_ms);
+            virtual void subscribe();
+            virtual void stop();
+            virtual void printCurrConf();
+            virtual bool is_running() const;
+            virtual ~kafka_consumer_worker() = default;
     };
 }
 

--- a/kafka_clients/include/kafka_consumer_worker.h
+++ b/kafka_clients/include/kafka_consumer_worker.h
@@ -136,13 +136,53 @@ namespace kafka_clients
             const char* msg_consume(RdKafka::Message *message, void *opaque);
 
         public:
+            /**
+             * @brief Construct a new kafka consumer worker object
+             * 
+             * @param broker_str network adress of kafka broker.
+             * @param topic_str topic consumer should consume from.
+             * @param group_id consumer group id.
+             * @param cur_offset offset to start event consuming at. Defaults to 0.
+             * @param partition partition consumer should be assigned to.
+             */
             kafka_consumer_worker(const std::string &broker_str, const std::string &topic_str, const std::string & group_id, int64_t cur_offset = 0, int32_t partition = 0);
+            /**
+             * @brief Initialize kafka_consumer_worker
+             * 
+             * @return true if successful.
+             * @return false if unsuccessful.
+             */
             virtual bool init();
+            /**
+             * @brief Consume from topic.
+             * 
+             * @param timeout_ms timeout in milliseconds to wait before failing.;
+             * @return const char* of payload consumed.
+             */
             virtual const char* consume(int timeout_ms);
+            /**
+             * @brief Subscribe consumer to topic
+             */
             virtual void subscribe();
+            /**
+             * @brief Stop running kafka consumer.
+             */
             virtual void stop();
+            /**
+             * @brief Print current configurations.
+             */
             virtual void printCurrConf();
+            /**
+             * @brief Is kafka_consumer_worker still running?
+             * 
+             * @return true if kafka consumer is still running.
+             * @return false if kafka consumer is stopped.
+             */
             virtual bool is_running() const;
+            /**
+             * @brief Destroy the kafka consumer worker object
+             * 
+             */
             virtual ~kafka_consumer_worker() = default;
     };
 }

--- a/kafka_clients/include/mock_kafka_consumer_worker.h
+++ b/kafka_clients/include/mock_kafka_consumer_worker.h
@@ -2,14 +2,21 @@
 #include "kafka_consumer_worker.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
-class mock_kafka_consumer_worker : public kafka_clients::kafka_consumer_worker {
-    public:
-        MOCK_METHOD(bool, init,(),(override));
-        MOCK_METHOD(const char*, consume, (int timeout_ms), (override));
-        MOCK_METHOD(void, subscribe, (), (override));
-        MOCK_METHOD(void, stop, (), (override));
-        MOCK_METHOD(void, printCurrConf, (), (override));
-        MOCK_METHOD(bool, is_running, (), (const override));
-        ~mock_kafka_consumer_worker()= default;
+#include <spdlog/spdlog.h>
+namespace kafka_clients {
+    class mock_kafka_consumer_worker : public kafka_clients::kafka_consumer_worker {
+        public:
+            mock_kafka_consumer_worker(const std::string &broker_str="",
+                                        const std::string &topic_str="", 
+                                        const std::string &group_id="", 
+                                        int64_t cur_offset = 0, 
+                                        int32_t partition = 0) : kafka_consumer_worker(broker_str,topic_str, group_id, cur_offset, partition ) 
+                                        {}
+            MOCK_METHOD(bool, init,(),(override));
+            MOCK_METHOD(const char*, consume, (int timeout_ms), (override));
+            MOCK_METHOD(void, subscribe, (), (override));
+            MOCK_METHOD(void, stop, (), (override));
+            MOCK_METHOD(void, printCurrConf, (), (override));
+            MOCK_METHOD(bool, is_running, (), (const override));
+    };
 }

--- a/kafka_clients/include/mock_kafka_consumer_worker.h
+++ b/kafka_clients/include/mock_kafka_consumer_worker.h
@@ -4,8 +4,23 @@
 #include <gtest/gtest.h>
 #include <spdlog/spdlog.h>
 namespace kafka_clients {
+    /**
+     * @brief Mock kafka consumer used for unit testing using gmock. For documentation using gmock mocks 
+     * (https://google.github.io/googletest/gmock_for_dummies.html).
+     * 
+     * @author
+     */
     class mock_kafka_consumer_worker : public kafka_clients::kafka_consumer_worker {
         public:
+            /**
+             * @brief Mock constructor with all default parameters. Can be used as an default constructor.
+             * 
+             * @param broker_str 
+             * @param topic_str 
+             * @param group_id 
+             * @param cur_offset 
+             * @param partition 
+             */
             mock_kafka_consumer_worker(const std::string &broker_str="",
                                         const std::string &topic_str="", 
                                         const std::string &group_id="", 

--- a/kafka_clients/include/mock_kafka_consumer_worker.h
+++ b/kafka_clients/include/mock_kafka_consumer_worker.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "kafka_consumer_worker.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+class mock_kafka_consumer_worker : public kafka_clients::kafka_consumer_worker {
+    public:
+        MOCK_METHOD(bool, init,(),(override));
+        MOCK_METHOD(const char*, consume, (int timeout_ms), (override));
+        MOCK_METHOD(void, subscribe, (), (override));
+        MOCK_METHOD(void, stop, (), (override));
+        MOCK_METHOD(void, printCurrConf, (), (override));
+        MOCK_METHOD(bool, is_running, (), (const override));
+        ~mock_kafka_consumer_worker()= default;
+}

--- a/scheduling_service/manifest.json
+++ b/scheduling_service/manifest.json
@@ -41,7 +41,7 @@
         {
             "name": "exp_delta",
             "value": 60000,
-            "description": "Time(in milliseconds) without receiving status & intent updates after which a vehicle is no longer considered!",
+            "description": "Time(in milliseconds) without receiving status & intent updates after which a vehicle is removed from the vehicle list!",
             "type": "INTEGER"
         },
         {

--- a/scheduling_service/src/scheduling_service.cpp
+++ b/scheduling_service/src/scheduling_service.cpp
@@ -173,15 +173,11 @@ namespace scheduling_service{
         {
             
             const std::string payload = consumer_worker->consume(1000);
-            try {
             if(payload.length() != 0 && vehicle_list_ptr)
             {                
 
                 vehicle_list_ptr->process_update(payload);
     
-            }}
-            catch(const streets_vehicles::status_intent_processing_exception &e) {
-                SPDLOG_ERROR("Exception encounter during update parsing! \n{0}", e.what());
             }
         }
         SPDLOG_WARN("Stopping status and intent consumer thread!");

--- a/signal_opt_service/CMakeLists.txt
+++ b/signal_opt_service/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(Qt5Network REQUIRED)
 find_package(streets_service_base_lib COMPONENTS streets_service_base_lib REQUIRED)
 find_package(streets_vehicle_list_lib COMPONENTS streets_vehicle_list_lib REQUIRED)
 find_package(streets_signal_phase_and_timing_lib COMPONENTS streets_signal_phase_and_timing_lib REQUIRED)
-find_package(streets_tsc_configuration_lib)
+find_package(streets_tsc_configuration_lib COMPONENTS streets_tsc_configuration_lib REQUIRED )
 
 add_library(${PROJECT_NAME}_lib
     src/signal_opt_service.cpp

--- a/signal_opt_service/CMakeLists.txt
+++ b/signal_opt_service/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(Qt5Network REQUIRED)
 find_package(streets_service_base_lib COMPONENTS streets_service_base_lib REQUIRED)
 find_package(streets_vehicle_list_lib COMPONENTS streets_vehicle_list_lib REQUIRED)
 find_package(streets_signal_phase_and_timing_lib COMPONENTS streets_signal_phase_and_timing_lib REQUIRED)
+find_package(streets_tsc_configuration_lib)
 
 add_library(${PROJECT_NAME}_lib
     src/signal_opt_service.cpp
@@ -41,6 +42,7 @@ target_link_libraries(${PROJECT_NAME}_lib PUBLIC
     streets_service_base_lib::streets_service_base_lib
     streets_vehicle_list_lib::streets_vehicle_list_lib
     streets_signal_phase_and_timing_lib::streets_signal_phase_and_timing_lib
+    streets_tsc_configuration_lib::streets_tsc_configuration_lib
     Qt5::Core
     Qt5::Network
 )

--- a/signal_opt_service/CMakeLists.txt
+++ b/signal_opt_service/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(${BINARY} PUBLIC
     spdlog::spdlog
     rapidjson
     gtest
+    gmock
     Qt5::Core
     Qt5::Network
     intersection_client_api_lib

--- a/signal_opt_service/Dockerfile
+++ b/signal_opt_service/Dockerfile
@@ -80,6 +80,14 @@ RUN cmake -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_C_FLAGS="${COVERAGE_FLAG
 RUN make
 RUN make install
 
+RUN echo " ------> Install streets_tsc_configuration library from streets_utils..."
+WORKDIR /home/carma-streets/streets_utils/streets_tsc_configuration
+RUN mkdir build
+WORKDIR /home/carma-streets/streets_utils/streets_tsc_configuration/build
+RUN cmake -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_BUILD_TYPE="Debug" ..
+RUN make
+RUN make install
+
 # Install kafka-clients
 RUN echo " ------> Install kafka-clients..."
 COPY ./kafka_clients/ /home/carma-streets/kafka_clients

--- a/signal_opt_service/include/movement_group.h
+++ b/signal_opt_service/include/movement_group.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <list>
+
+namespace signal_opt_service
+{
+    struct movement_group
+    {
+        std::string name;
+
+        std::pair<int,int> signal_groups;
+    };
+
+    struct movement_groups {
+        std::list<movement_group> groups;
+    };
+} // namespace signal_opt_service
+
+

--- a/signal_opt_service/include/movement_group.h
+++ b/signal_opt_service/include/movement_group.h
@@ -2,14 +2,36 @@
 #include <list>
 
 namespace signal_opt_service
-{
+{   
+    /**
+     * @brief Movement group consists of up to two signal group ids which can concurrently be
+     * given green in a NEMA 8 Phase Dual Ring Traffic Signal Controller setup. Each single group
+     * will be from a different ring but both are inside the same barrier. A signal group pair with 
+     * an entry of 0 indicates the movement group only consists of a single signal group (the non-zero 
+     * value entry). 
+     * 
+     */
     struct movement_group
     {
+        /**
+         * @brief Optional parameter to identify movement group
+         * 
+         */
         std::string name;
-
+        /**
+         * @brief Up to two signal group ids from different rings but a common barrier in a Dual Ring 8 Phase TSC setup.
+         * Entries where one item in the pair is 0 will be treated as movement groups with only a single single group. Entries
+         * where both items in the pair are zero are invalid.
+         * 
+         */
         std::pair<int,int> signal_groups;
     };
-
+    /**
+     * @brief This struct is a list of movement groups. All the elements in this list should be unique. This
+     * means that each signal group pair should be unique in this list. This is NOT enforced by the struct and 
+     * should be ensured when populating the list.
+     * 
+     */
     struct movement_groups {
         std::list<movement_group> groups;
     };

--- a/signal_opt_service/include/signal_opt_messages_worker.h
+++ b/signal_opt_service/include/signal_opt_messages_worker.h
@@ -38,7 +38,7 @@ namespace signal_opt_service
          * @return true if the vehicle list is updated.
          * @return false if the vehilce list is not updated.
          */
-        bool add_update_vehicle(const std::string& vehicle_json) const;
+        bool update_vehicle_list(const std::string& vehicle_json) const;
         /**
          * @brief Spat string from kafka stream in JSON format. Updating the spat with the latest spat info calling the signal_phase_timing library
          * @param spat_json Spat string from kafka stream in JSON format.
@@ -47,7 +47,7 @@ namespace signal_opt_service
          */
         bool update_spat(const std::string& spat_json);
 
-        bool update_configuration(const std::string &tsc_configuration);
+        bool update_tsc_config(const std::string &tsc_configuration);
         /**
          * @brief Send http GET request to intersection model at rate of configured HZ until it gets the valid (!= 0) signal group id from the intersection info.
          * Updating the intersection info with the http response that has the valid signal group id, and stop sending any more GET request.
@@ -60,16 +60,18 @@ namespace signal_opt_service
          * @brief Get the const intersection info pointer which does not allow caller to update the intersection info
          * @return A constant intersection info pointer to prevent any update
          */
-        const std::shared_ptr<OpenAPI::OAIIntersection_info>& get_intersection_info() const;
+        std::shared_ptr<OpenAPI::OAIIntersection_info> get_intersection_info_ptr() const;
         /**
          * @brief Get the const vehicle list pointer which does not allow caller to update the vehicle list
          * @return A constant vehicle list pointer to prevent any update
          */
-        const std::shared_ptr<streets_vehicles::vehicle_list>& get_vehicle_list() const;
+        std::shared_ptr<streets_vehicles::vehicle_list> get_vehicle_list_ptr() const;
         /**
          * @brief Get the latest spat object pointer
          * @return A constant spat pointer to prevent any update
          */
-        const std::shared_ptr<signal_phase_and_timing::spat>& get_latest_spat() const;
+        std::shared_ptr<signal_phase_and_timing::spat> get_spat_ptr() const;
+
+        std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> get_tsc_config_ptr() const;
     };
 }

--- a/signal_opt_service/include/signal_opt_messages_worker.h
+++ b/signal_opt_service/include/signal_opt_messages_worker.h
@@ -30,6 +30,7 @@ namespace signal_opt_service
         /**
          * @brief Vehicle string from kafka stream in JSON format. Calling vehicle list library to persist vehicles.
          * @param vehicle_json Vehicle string from kafka stream in JSON format.
+         * @param vehicle_list_ptr shared pointer to the vehicle list object.
          * @return true if the vehicle list is updated.
          * @return false if the vehilce list is not updated.
          */
@@ -37,17 +38,25 @@ namespace signal_opt_service
         /**
          * @brief Spat string from kafka stream in JSON format. Updating the spat with the latest spat info calling the signal_phase_timing library
          * @param spat_json Spat string from kafka stream in JSON format.
+         * @param spat_ptr shared pointer to the spat object.
          * @return true if the Spat object is updated.
          * @return false if the Spat object is not updated.
          */
         bool update_spat(const std::string& spat_json , std::shared_ptr<signal_phase_and_timing::spat> spat_ptr) const ;
-
+        /**
+         * @brief Update tsc configuration state shared pointer using json string update.
+         * 
+         * @param tsc_configuration std::string json update
+         * @param tsc_configuration_ptr shared pointer to tsc configuration state object.
+         * @return true if tsc configuration state object is successfully updated using json update message.
+         * @return false false if tsc configuration state object fails to update using json update message.
+         */
         bool update_tsc_config(const std::string &tsc_configuration, 
                                 std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr) const ;
         /**
          * @brief Send http GET request to intersection model at rate of configured HZ until it gets the valid (!= 0) signal group id from the intersection info.
          * Updating the intersection info with the http response that has the valid signal group id, and stop sending any more GET request.
-         * @param int_info Http response from intersection model
+         * @param _intersection_info shared pointer to the intersection info object.
          * @return true if intersection information is updated upon receiving valid signal group id.
          * @return false if intersection information is not updated.
          */

--- a/signal_opt_service/include/signal_opt_messages_worker.h
+++ b/signal_opt_service/include/signal_opt_messages_worker.h
@@ -16,6 +16,7 @@
 #include "vehicle_list.h"
 #include "signalized_status_intent_processor.h"
 #include "spat.h"
+#include "tsc_configuration_state.h"
 
 namespace signal_opt_service
 {
@@ -25,6 +26,7 @@ namespace signal_opt_service
         std::shared_ptr<OpenAPI::OAIIntersection_info> intersection_info_ptr;
         std::shared_ptr<signal_phase_and_timing::spat> spat_ptr;
         std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list_ptr;
+        std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr;
 
     public:
         signal_opt_messages_worker();
@@ -44,6 +46,8 @@ namespace signal_opt_service
          * @return false if the Spat object is not updated.
          */
         bool update_spat(const std::string& spat_json);
+
+        bool update_configuration(const std::string &tsc_configuration);
         /**
          * @brief Send http GET request to intersection model at rate of configured HZ until it gets the valid (!= 0) signal group id from the intersection info.
          * Updating the intersection info with the http response that has the valid signal group id, and stop sending any more GET request.

--- a/signal_opt_service/include/signal_opt_messages_worker.h
+++ b/signal_opt_service/include/signal_opt_messages_worker.h
@@ -22,11 +22,6 @@ namespace signal_opt_service
 {
     class signal_opt_messages_worker: public QObject
     {
-    private:
-        std::shared_ptr<OpenAPI::OAIIntersection_info> intersection_info_ptr;
-        std::shared_ptr<signal_phase_and_timing::spat> spat_ptr;
-        std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list_ptr;
-        std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr;
 
     public:
         signal_opt_messages_worker();
@@ -38,16 +33,17 @@ namespace signal_opt_service
          * @return true if the vehicle list is updated.
          * @return false if the vehilce list is not updated.
          */
-        bool update_vehicle_list(const std::string& vehicle_json) const;
+        bool update_vehicle_list(const std::string& vehicle_json, std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list_ptr ) const;
         /**
          * @brief Spat string from kafka stream in JSON format. Updating the spat with the latest spat info calling the signal_phase_timing library
          * @param spat_json Spat string from kafka stream in JSON format.
          * @return true if the Spat object is updated.
          * @return false if the Spat object is not updated.
          */
-        bool update_spat(const std::string& spat_json);
+        bool update_spat(const std::string& spat_json , std::shared_ptr<signal_phase_and_timing::spat> spat_ptr);
 
-        bool update_tsc_config(const std::string &tsc_configuration);
+        bool update_tsc_config(const std::string &tsc_configuration, 
+                                std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr);
         /**
          * @brief Send http GET request to intersection model at rate of configured HZ until it gets the valid (!= 0) signal group id from the intersection info.
          * Updating the intersection info with the http response that has the valid signal group id, and stop sending any more GET request.
@@ -55,23 +51,6 @@ namespace signal_opt_service
          * @return true if intersection information is updated upon receiving valid signal group id.
          * @return false if intersection information is not updated.
          */
-        bool request_intersection_info();
-        /**
-         * @brief Get the const intersection info pointer which does not allow caller to update the intersection info
-         * @return A constant intersection info pointer to prevent any update
-         */
-        std::shared_ptr<OpenAPI::OAIIntersection_info> get_intersection_info_ptr() const;
-        /**
-         * @brief Get the const vehicle list pointer which does not allow caller to update the vehicle list
-         * @return A constant vehicle list pointer to prevent any update
-         */
-        std::shared_ptr<streets_vehicles::vehicle_list> get_vehicle_list_ptr() const;
-        /**
-         * @brief Get the latest spat object pointer
-         * @return A constant spat pointer to prevent any update
-         */
-        std::shared_ptr<signal_phase_and_timing::spat> get_spat_ptr() const;
-
-        std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> get_tsc_config_ptr() const;
+        bool request_intersection_info(std::shared_ptr<OpenAPI::OAIIntersection_info> _intersection_info);
     };
 }

--- a/signal_opt_service/include/signal_opt_messages_worker.h
+++ b/signal_opt_service/include/signal_opt_messages_worker.h
@@ -40,10 +40,10 @@ namespace signal_opt_service
          * @return true if the Spat object is updated.
          * @return false if the Spat object is not updated.
          */
-        bool update_spat(const std::string& spat_json , std::shared_ptr<signal_phase_and_timing::spat> spat_ptr);
+        bool update_spat(const std::string& spat_json , std::shared_ptr<signal_phase_and_timing::spat> spat_ptr) const ;
 
         bool update_tsc_config(const std::string &tsc_configuration, 
-                                std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr);
+                                std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr) const ;
         /**
          * @brief Send http GET request to intersection model at rate of configured HZ until it gets the valid (!= 0) signal group id from the intersection info.
          * Updating the intersection info with the http response that has the valid signal group id, and stop sending any more GET request.
@@ -51,6 +51,6 @@ namespace signal_opt_service
          * @return true if intersection information is updated upon receiving valid signal group id.
          * @return false if intersection information is not updated.
          */
-        bool request_intersection_info(std::shared_ptr<OpenAPI::OAIIntersection_info> _intersection_info);
+        bool request_intersection_info(std::shared_ptr<OpenAPI::OAIIntersection_info> _intersection_info) const;
     };
 }

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -19,6 +19,7 @@ namespace signal_opt_service
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _vsi_consumer;
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _spat_consumer;
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _tsc_config_consumer;
+        std::shared_ptr<std::list<std::pair<int, int>>> _movement_groups;
 
     public:
         /**
@@ -43,6 +44,9 @@ namespace signal_opt_service
         void consume_vsi() const;
 
         void consume_tsc_config() const;
+
+        void populate_movement_groups();
+        
 
         /**
          * @brief Updating the intersection info.

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -21,6 +21,10 @@ namespace signal_opt_service
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _spat_consumer;
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _tsc_config_consumer;
         std::shared_ptr<movement_groups> _movement_groups;
+        std::shared_ptr<OpenAPI::OAIIntersection_info> intersection_info_ptr;
+        std::shared_ptr<signal_phase_and_timing::spat> spat_ptr;
+        std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list_ptr;
+        std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr;
 
     public:
         /**
@@ -44,20 +48,23 @@ namespace signal_opt_service
          * spat pointer in signal_opt_message_worker. 
          * 
          */
-        void consume_spat() const;
+        void consume_spat( const std::shared_ptr<kafka_clients::kafka_consumer_worker> spat_consumer,
+                            const std::shared_ptr<signal_phase_and_timing::spat> _spat_ptr ) const;
         /**
          * @brief Method to consume vehicle status and intent JSON from kafka 
          * consumer and update vehicle list pointer in signal_opt_message_worker.
          * 
          */
-        void consume_vsi() const;
+        void consume_vsi(const std::shared_ptr<kafka_clients::kafka_consumer_worker> vsi_consumer,
+                            const std::shared_ptr<streets_vehicles::vehicle_list> _vehicle_list_ptr) const;
         /**
          * @brief Method to consume a single TSC Configuration JSON message 
          * from kafka and update the tsc_config_state pointer in the 
          * signal_opt_message_worker.
          * 
          */
-        void consume_tsc_config() const;
+        void consume_tsc_config(const std::shared_ptr<kafka_clients::kafka_consumer_worker> tsc_config_consumer, 
+                                const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> _tsc_config_ptr) const;
         /**
          * @brief Method to use the tsc_config_state pointer from the 
          * signal_opt_message_worker to populate movement_groups pointer

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -2,6 +2,7 @@
 #include "kafka_client.h"
 #include "signal_opt_messages_worker.h"
 #include "streets_configuration.h"
+#include "movement_group.h"
 
 namespace signal_opt_service
 {
@@ -19,7 +20,7 @@ namespace signal_opt_service
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _vsi_consumer;
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _spat_consumer;
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _tsc_config_consumer;
-        std::shared_ptr<std::list<std::pair<int, int>>> _movement_groups;
+        std::shared_ptr<movement_groups> _movement_groups;
 
     public:
         /**
@@ -38,16 +39,33 @@ namespace signal_opt_service
          * @brief Create threads and consume messages
          */
         void start();
-
+        /**
+         * @brief Method to consume SPaT JSON from kafka consumer and update 
+         * spat pointer in signal_opt_message_worker. 
+         * 
+         */
         void consume_spat() const;
-
+        /**
+         * @brief Method to consume vehicle status and intent JSON from kafka 
+         * consumer and update vehicle list pointer in signal_opt_message_worker.
+         * 
+         */
         void consume_vsi() const;
-
+        /**
+         * @brief Method to consume a single TSC Configuration JSON message 
+         * from kafka and update the tsc_config_state pointer in the 
+         * signal_opt_message_worker.
+         * 
+         */
         void consume_tsc_config() const;
-
-        void populate_movement_groups();
-        
-
+        /**
+         * @brief Method to use the tsc_config_state pointer from the 
+         * signal_opt_message_worker to populate movement_groups pointer
+         * 
+         * @param movement_groups shared pointer to list of movement groups
+         */
+        void populate_movement_groups(std::shared_ptr<movement_groups> _groups, 
+                                    const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config) ;
         /**
          * @brief Updating the intersection info.
          * @param sleep_millisecs The current thread sleep for milliseconds after each update attempt

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -37,7 +37,7 @@ namespace signal_opt_service
         /**
          * @brief Create threads and consume messages
          */
-        void start() const;
+        void start();
 
         void consume_spat() const;
 

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -72,7 +72,7 @@ namespace signal_opt_service
          * @param movement_groups shared pointer to list of movement groups
          */
         void populate_movement_groups(std::shared_ptr<movement_groups> _groups, 
-                                    const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config) ;
+                                    const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config) const ;
         /**
          * @brief Updating the intersection info.
          * @param sleep_millisecs The current thread sleep for milliseconds after each update attempt

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -5,13 +5,6 @@
 
 namespace signal_opt_service
 {
-    enum class CONSUME_MSG_TYPE
-    {
-        SPAT,
-        VEHICLE_STATUS_INTENT,
-        TSC_CONFIGURATION
-    };
-
     class signal_opt_service
     {
     private:
@@ -45,12 +38,12 @@ namespace signal_opt_service
          */
         void start() const;
 
-        /**
-         * @brief Consume the different types of kafka stream via kafka consumers
-         * @param msg_json The consumed kafka stream in JSON format
-         * @param consume_msg_type The type of message consumed by the kafka consumer
-         */
-        void consume_msg(std::shared_ptr<kafka_clients::kafka_consumer_worker> consumer, CONSUME_MSG_TYPE consume_msg_type) const;
+        void consume_spat() const;
+
+        void consume_vsi() const;
+
+        void consume_tsc_config() const;
+
         /**
          * @brief Updating the intersection info.
          * @param sleep_millisecs The current thread sleep for milliseconds after each update attempt

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -9,6 +9,7 @@ namespace signal_opt_service
     {
         SPAT,
         VEHICLE_STATUS_INTENT,
+        TSC_CONFIGURATION
     };
 
     class signal_opt_service
@@ -20,8 +21,11 @@ namespace signal_opt_service
         std::string _spat_topic_name;
         std::string _vsi_group_id;
         std::string _vsi_topic_name;
+        std::string _tsc_config_group_id;
+        std::string _tsc_config_topic_name;
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _vsi_consumer;
         std::shared_ptr<kafka_clients::kafka_consumer_worker> _spat_consumer;
+        std::shared_ptr<kafka_clients::kafka_consumer_worker> _tsc_config_consumer;
 
     public:
         /**

--- a/signal_opt_service/include/signal_opt_service.h
+++ b/signal_opt_service/include/signal_opt_service.h
@@ -44,24 +44,28 @@ namespace signal_opt_service
          */
         void start();
         /**
-         * @brief Method to consume SPaT JSON from kafka consumer and update 
-         * spat pointer in signal_opt_message_worker. 
+         * @brief Method to consume SPaT JSON from kafka consumer and update spat pointer.
          * 
+         * @param spat_consumer shared pointer to kafka consumer.
+         * @param _spat_ptr shared pointer to spat object.
          */
         void consume_spat( const std::shared_ptr<kafka_clients::kafka_consumer_worker> spat_consumer,
                             const std::shared_ptr<signal_phase_and_timing::spat> _spat_ptr ) const;
         /**
          * @brief Method to consume vehicle status and intent JSON from kafka 
-         * consumer and update vehicle list pointer in signal_opt_message_worker.
+         * consumer and vehicle list pointer.
          * 
+         * @param vsi_consumer shared pointer to kafka consumer.
+         * @param _vehicle_list_ptr shared pointer to vehicle list object.
          */
         void consume_vsi(const std::shared_ptr<kafka_clients::kafka_consumer_worker> vsi_consumer,
                             const std::shared_ptr<streets_vehicles::vehicle_list> _vehicle_list_ptr) const;
         /**
          * @brief Method to consume a single TSC Configuration JSON message 
-         * from kafka and update the tsc_config_state pointer in the 
-         * signal_opt_message_worker.
+         * from kafka and update the tsc configuration state pointer.
          * 
+         * @param tsc_config_consumer shared pointer to kafka consumer.
+         * @param _tsc_config_ptr shared pointer to tsc configuration state pointer.
          */
         void consume_tsc_config(const std::shared_ptr<kafka_clients::kafka_consumer_worker> tsc_config_consumer, 
                                 const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> _tsc_config_ptr) const;
@@ -70,6 +74,7 @@ namespace signal_opt_service
          * signal_opt_message_worker to populate movement_groups pointer
          * 
          * @param movement_groups shared pointer to list of movement groups
+         * @param tsc_config shared pointer to tsc configuration state object.
          */
         void populate_movement_groups(std::shared_ptr<movement_groups> _groups, 
                                     const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config) const ;

--- a/signal_opt_service/manifest.json
+++ b/signal_opt_service/manifest.json
@@ -33,6 +33,12 @@
             "type": "STRING"
         },
         {
+            "name": "exp_delta",
+            "value": 60000,
+            "description": "Time(in milliseconds) without receiving status & intent updates after which a vehicle is removed from the vehicle list!",
+            "type": "INTEGER"
+        },
+        {
             "name": "sleep_millisecs",
             "value": 5000,
             "description": "Current thread sleep for milliseconds",

--- a/signal_opt_service/manifest.json
+++ b/signal_opt_service/manifest.json
@@ -43,6 +43,18 @@
             "value": 10,
             "description": "Number of attempts intersection client sending the HTTP request to get response with valid signal group ids.",
             "type": "INTEGER"
+        },
+        {
+            "name": "tsc_config_consumer_topic",
+            "value": "tsc_config_state",
+            "description": "Kafka topic for CARMA Streets internal traffic signal controller phase configuration message.",
+            "type": "STRING"
+        },
+        {
+            "name": "tsc_config_group_id",
+            "value": "tsc_config_group",
+            "description": "Kafka consumer group for SO tsc_config_consumer.",
+            "type": "STRING"
         }
     ]
 }

--- a/signal_opt_service/readme.md
+++ b/signal_opt_service/readme.md
@@ -1,4 +1,4 @@
-## Singal Optimization Service
+## Signal Optimization Service
 ### Introduction
 The SO (Signal Optimization) service is the CARMA-Streets service responsible for optimizing traffic signal controller phase order and duration. The SO service is responsible for fixing a configurable amount of future phases on the traffic signal controller. On each phase transition (Yellow and Red clearance interval), the SO service will determine a new phase and duration to append to the list of fixed phases. The SO service does this by monitoring traffic signal state and planned state, vehicles within the intersection communication area, and the latest intersection geometry. 
 

--- a/signal_opt_service/src/signal_opt_messages_worker.cpp
+++ b/signal_opt_service/src/signal_opt_messages_worker.cpp
@@ -16,14 +16,8 @@ namespace signal_opt_service
     {
         if (this->vehicle_list_ptr)
         {
-            try {
-                this->vehicle_list_ptr->process_update(vehicle_json);
-                return true;
-            }
-            catch( const streets_vehicles::status_intent_processing_exception &e) {
-                SPDLOG_ERROR("Exception encountered during Status and Intent processing! \n {0}", e.what());
-                return false;
-            }
+            this->vehicle_list_ptr->process_update(vehicle_json);
+            return true;  
         }
         return false;
     }

--- a/signal_opt_service/src/signal_opt_messages_worker.cpp
+++ b/signal_opt_service/src/signal_opt_messages_worker.cpp
@@ -5,29 +5,25 @@ namespace signal_opt_service
     signal_opt_messages_worker::signal_opt_messages_worker()
     {
         SPDLOG_DEBUG("Construct signal_opt_messages_worker");
-        this->intersection_info_ptr = std::make_shared<OpenAPI::OAIIntersection_info>();
-        this->vehicle_list_ptr = std::make_shared<streets_vehicles::vehicle_list>();
-        this->vehicle_list_ptr->set_processor(std::make_shared<streets_vehicles::signalized_status_intent_processor>());
-        this->spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
-        this->tsc_configuration_ptr = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
+        
     }
 
-    bool signal_opt_messages_worker::update_vehicle_list(const std::string &vehicle_json) const
+    bool signal_opt_messages_worker::update_vehicle_list(const std::string &vehicle_json, std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list_ptr) const
     {
-        if (this->vehicle_list_ptr)
+        if (vehicle_list_ptr)
         {
-            this->vehicle_list_ptr->process_update(vehicle_json);
+            vehicle_list_ptr->process_update(vehicle_json);
             return true;  
         }
         return false;
     }
 
-    bool signal_opt_messages_worker::update_spat(const std::string &spat_json)
+    bool signal_opt_messages_worker::update_spat(const std::string &spat_json, std::shared_ptr<signal_phase_and_timing::spat> spat_ptr)
     {
-        if (this->spat_ptr)
+        if (spat_ptr)
         {
             try {
-                this->spat_ptr->fromJson(spat_json);
+                spat_ptr->fromJson(spat_json);
                 return true;
             }
             catch( const signal_phase_and_timing::signal_phase_and_timing_exception &e) {
@@ -38,10 +34,12 @@ namespace signal_opt_service
 
         return false;
     }
-    bool signal_opt_messages_worker::update_tsc_config(const std::string &tsc_configuration) {
-        if (this->tsc_configuration_ptr) {
+    bool signal_opt_messages_worker::update_tsc_config(const std::string &tsc_configuration, 
+                                                       std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr) {
+        if (tsc_configuration_ptr) {
+            SPDLOG_INFO("Is this happening");
             try {
-                this->tsc_configuration_ptr->fromJson(tsc_configuration);
+                tsc_configuration_ptr->fromJson(tsc_configuration);
                 return true;
             }
             catch( const streets_tsc_configuration::tsc_configuration_state_exception &e) {
@@ -52,13 +50,13 @@ namespace signal_opt_service
         return false;
     }
 
-    bool signal_opt_messages_worker::request_intersection_info()
+    bool signal_opt_messages_worker::request_intersection_info( std::shared_ptr<OpenAPI::OAIIntersection_info> intersection_info_ptr)
     {
         int invalid_signal_group_count = 0;
         bool signal_group_ids_valid = false;
         OpenAPI::OAIDefaultApi apiInstance;
         QEventLoop loop;
-        connect(&apiInstance, &OpenAPI::OAIDefaultApi::getIntersectionInfoSignal, [this, &signal_group_ids_valid, &invalid_signal_group_count, &loop](OpenAPI::OAIIntersection_info int_info)
+        connect(&apiInstance, &OpenAPI::OAIDefaultApi::getIntersectionInfoSignal, [this, intersection_info_ptr, &signal_group_ids_valid, &invalid_signal_group_count, &loop](OpenAPI::OAIIntersection_info int_info)
                 {                   
                     SPDLOG_INFO("request_intersection_info receives intersection information. Checking signal group ids update...");
                     QList<OpenAPI::OAILanelet_info> ll_info_list = int_info.getLinkLanelets();
@@ -70,7 +68,11 @@ namespace signal_opt_service
                     if(invalid_signal_group_count == 0)
                     {
                         //Update intersection info 
-                        this->intersection_info_ptr = std::make_shared<OpenAPI::OAIIntersection_info>(int_info); 
+                        intersection_info_ptr->setId(int_info.getId());
+                        intersection_info_ptr->setName(int_info.getName());
+                        intersection_info_ptr->setEntryLanelets(int_info.getEntryLanelets());
+                        intersection_info_ptr->setLinkLanelets(int_info.getLinkLanelets());
+                        intersection_info_ptr->setDepartureLanelets(int_info.getDepartureLanelets()); 
                         signal_group_ids_valid = true;
                         SPDLOG_INFO("Intersection information is updated with valid signal group ids! ");
                     }
@@ -87,25 +89,5 @@ namespace signal_opt_service
         QTimer::singleShot(5000, &loop, &QEventLoop::quit);
         loop.exec();
         return signal_group_ids_valid;
-    }
-
-    std::shared_ptr<OpenAPI::OAIIntersection_info> signal_opt_messages_worker::get_intersection_info_ptr() const
-    {
-        return this->intersection_info_ptr;
-    }
-
-    std::shared_ptr<streets_vehicles::vehicle_list> signal_opt_messages_worker::get_vehicle_list_ptr() const
-    {
-        return this->vehicle_list_ptr;
-    }
-
-    std::shared_ptr<signal_phase_and_timing::spat> signal_opt_messages_worker::get_spat_ptr() const
-    {
-        return this->spat_ptr;
-    }
-
-    std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> signal_opt_messages_worker::get_tsc_config_ptr() const 
-    {
-        return this->tsc_configuration_ptr;
     }
 }

--- a/signal_opt_service/src/signal_opt_messages_worker.cpp
+++ b/signal_opt_service/src/signal_opt_messages_worker.cpp
@@ -8,7 +8,8 @@ namespace signal_opt_service
         
     }
 
-    bool signal_opt_messages_worker::update_vehicle_list(const std::string &vehicle_json, std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list_ptr) const
+    bool signal_opt_messages_worker::update_vehicle_list(const std::string &vehicle_json, 
+                                                        std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list_ptr) const
     {
         if (vehicle_list_ptr)
         {
@@ -18,7 +19,7 @@ namespace signal_opt_service
         return false;
     }
 
-    bool signal_opt_messages_worker::update_spat(const std::string &spat_json, std::shared_ptr<signal_phase_and_timing::spat> spat_ptr)
+    bool signal_opt_messages_worker::update_spat(const std::string &spat_json, std::shared_ptr<signal_phase_and_timing::spat> spat_ptr) const
     {
         if (spat_ptr)
         {
@@ -35,9 +36,8 @@ namespace signal_opt_service
         return false;
     }
     bool signal_opt_messages_worker::update_tsc_config(const std::string &tsc_configuration, 
-                                                       std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr) {
+                                                       std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_configuration_ptr) const {
         if (tsc_configuration_ptr) {
-            SPDLOG_INFO("Is this happening");
             try {
                 tsc_configuration_ptr->fromJson(tsc_configuration);
                 return true;
@@ -50,13 +50,16 @@ namespace signal_opt_service
         return false;
     }
 
-    bool signal_opt_messages_worker::request_intersection_info( std::shared_ptr<OpenAPI::OAIIntersection_info> intersection_info_ptr)
+    bool signal_opt_messages_worker::request_intersection_info( std::shared_ptr<OpenAPI::OAIIntersection_info> intersection_info_ptr) const
     {
         int invalid_signal_group_count = 0;
         bool signal_group_ids_valid = false;
         OpenAPI::OAIDefaultApi apiInstance;
         QEventLoop loop;
-        connect(&apiInstance, &OpenAPI::OAIDefaultApi::getIntersectionInfoSignal, [this, intersection_info_ptr, &signal_group_ids_valid, &invalid_signal_group_count, &loop](OpenAPI::OAIIntersection_info int_info)
+        connect(&apiInstance, &OpenAPI::OAIDefaultApi::getIntersectionInfoSignal, [ intersection_info_ptr, 
+                                                                                    &signal_group_ids_valid, 
+                                                                                    &invalid_signal_group_count, 
+                                                                                    &loop](const OpenAPI::OAIIntersection_info &int_info)
                 {                   
                     SPDLOG_INFO("request_intersection_info receives intersection information. Checking signal group ids update...");
                     QList<OpenAPI::OAILanelet_info> ll_info_list = int_info.getLinkLanelets();

--- a/signal_opt_service/src/signal_opt_messages_worker.cpp
+++ b/signal_opt_service/src/signal_opt_messages_worker.cpp
@@ -12,7 +12,7 @@ namespace signal_opt_service
         this->tsc_configuration_ptr = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
     }
 
-    bool signal_opt_messages_worker::add_update_vehicle(const std::string &vehicle_json) const
+    bool signal_opt_messages_worker::update_vehicle_list(const std::string &vehicle_json) const
     {
         if (this->vehicle_list_ptr)
         {
@@ -44,7 +44,7 @@ namespace signal_opt_service
 
         return false;
     }
-    bool signal_opt_messages_worker::update_configuration(const std::string &tsc_configuration) {
+    bool signal_opt_messages_worker::update_tsc_config(const std::string &tsc_configuration) {
         if (this->tsc_configuration_ptr) {
             try {
                 this->tsc_configuration_ptr->fromJson(tsc_configuration);
@@ -95,18 +95,23 @@ namespace signal_opt_service
         return signal_group_ids_valid;
     }
 
-    const std::shared_ptr<OpenAPI::OAIIntersection_info> &signal_opt_messages_worker::get_intersection_info() const
+    std::shared_ptr<OpenAPI::OAIIntersection_info> signal_opt_messages_worker::get_intersection_info_ptr() const
     {
         return this->intersection_info_ptr;
     }
 
-    const std::shared_ptr<streets_vehicles::vehicle_list> &signal_opt_messages_worker::get_vehicle_list() const
+    std::shared_ptr<streets_vehicles::vehicle_list> signal_opt_messages_worker::get_vehicle_list_ptr() const
     {
         return this->vehicle_list_ptr;
     }
 
-    const std::shared_ptr<signal_phase_and_timing::spat> &signal_opt_messages_worker::get_latest_spat() const
+    std::shared_ptr<signal_phase_and_timing::spat> signal_opt_messages_worker::get_spat_ptr() const
     {
         return this->spat_ptr;
+    }
+
+    std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> signal_opt_messages_worker::get_tsc_config_ptr() const 
+    {
+        return this->tsc_configuration_ptr;
     }
 }

--- a/signal_opt_service/src/signal_opt_service.cpp
+++ b/signal_opt_service/src/signal_opt_service.cpp
@@ -61,7 +61,7 @@ namespace signal_opt_service
         }
     }
 
-    void signal_opt_service::start() const
+    void signal_opt_service::start()
     {
         std::thread spat_t(&signal_opt_service::consume_spat, this);
         std::thread vsi_t(&signal_opt_service::consume_vsi, this);

--- a/signal_opt_service/src/signal_opt_service.cpp
+++ b/signal_opt_service/src/signal_opt_service.cpp
@@ -119,7 +119,7 @@ namespace signal_opt_service
     }
     
     void signal_opt_service::populate_movement_groups(std::shared_ptr<movement_groups> _groups, 
-                                                const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config) {
+                                                const std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config) const {
         if (tsc_config) {
             for (const auto &phase_config : tsc_config->tsc_config_list) {
                 for (const auto &concur : phase_config.concurrent_signal_groups) {

--- a/signal_opt_service/src/signal_opt_service.cpp
+++ b/signal_opt_service/src/signal_opt_service.cpp
@@ -10,7 +10,9 @@ namespace signal_opt_service
             _movement_groups = std::make_shared<movement_groups>();
             intersection_info_ptr = std::make_shared<OpenAPI::OAIIntersection_info>();
             vehicle_list_ptr = std::make_shared<streets_vehicles::vehicle_list>();
-            vehicle_list_ptr->set_processor(std::make_shared<streets_vehicles::signalized_status_intent_processor>());
+            auto processor = std::make_shared<streets_vehicles::signalized_status_intent_processor>();
+            processor->set_timeout(streets_service::streets_configuration("exp_delta"))
+            vehicle_list_ptr->set_processor(processor);
             spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
             tsc_configuration_ptr = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
 

--- a/signal_opt_service/src/signal_opt_service.cpp
+++ b/signal_opt_service/src/signal_opt_service.cpp
@@ -73,8 +73,10 @@ namespace signal_opt_service
     void signal_opt_service::consume_spat() const{
         while( _spat_consumer->is_running()) {
             const std::string payload = _spat_consumer->consume(1000); 
-            if (!_so_msgs_worker_ptr->update_spat(payload)) {
-                SPDLOG_CRITICAL("Failed to update SPaT with update {0}!", payload);
+            if (!payload.empty()) {
+                if (!_so_msgs_worker_ptr->update_spat(payload)) {
+                    SPDLOG_CRITICAL("Failed to update SPaT with update {0}!", payload);
+                }
             }
         }
     }
@@ -82,8 +84,10 @@ namespace signal_opt_service
     void signal_opt_service::consume_vsi() const{
         while( _vsi_consumer->is_running()) {
             const std::string payload = _vsi_consumer->consume(1000); 
-            if (!_so_msgs_worker_ptr->update_vehicle_list(payload)) {
-                SPDLOG_CRITICAL("Failed to update Vehicle List with update {0}!", payload);
+            if (!payload.empty()) {
+                if (!_so_msgs_worker_ptr->update_vehicle_list(payload)) {
+                    SPDLOG_CRITICAL("Failed to update Vehicle List with update {0}!", payload);
+                }
             }
         }
     }
@@ -91,8 +95,10 @@ namespace signal_opt_service
     void signal_opt_service::consume_tsc_config() const {
         while( _tsc_config_consumer->is_running()) {
             const std::string payload = _tsc_config_consumer->consume(1000); 
-            if (!_so_msgs_worker_ptr->update_tsc_config(payload)) {
-                SPDLOG_CRITICAL("Failed to update TSC Configuration with update {0}!", payload);
+            if (!payload.empty()) {
+                if (!_so_msgs_worker_ptr->update_tsc_config(payload)) {
+                    SPDLOG_CRITICAL("Failed to update TSC Configuration with update {0}!", payload);
+                }
             }
         }
     }

--- a/signal_opt_service/src/signal_opt_service.cpp
+++ b/signal_opt_service/src/signal_opt_service.cpp
@@ -11,7 +11,7 @@ namespace signal_opt_service
             intersection_info_ptr = std::make_shared<OpenAPI::OAIIntersection_info>();
             vehicle_list_ptr = std::make_shared<streets_vehicles::vehicle_list>();
             auto processor = std::make_shared<streets_vehicles::signalized_status_intent_processor>();
-            processor->set_timeout(streets_service::streets_configuration("exp_delta"))
+            processor->set_timeout(streets_service::streets_configuration::get_int_config("exp_delta"));
             vehicle_list_ptr->set_processor(processor);
             spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
             tsc_configuration_ptr = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();

--- a/signal_opt_service/src/signal_opt_service.cpp
+++ b/signal_opt_service/src/signal_opt_service.cpp
@@ -71,9 +71,12 @@ namespace signal_opt_service
     void signal_opt_service::start()
     {
         std::thread tsc_config_t(&signal_opt_service::consume_tsc_config, this, this->_tsc_config_consumer, this->tsc_configuration_ptr);
-        // Get TSC Information then populate movement groups.
+        // Block until TSC configuration information is received 
         tsc_config_t.join();
+        // After TSC configuration information is received, use it to determine movemement groups
         populate_movement_groups(_movement_groups, tsc_configuration_ptr);
+        // After movement groups are created, process vehicle status and intent and spat messages to
+        // maintain information about current vehicle states and TSC state
         std::thread vsi_t(&signal_opt_service::consume_vsi,  this, this->_vsi_consumer, this->vehicle_list_ptr);
         std::thread spat_t(&signal_opt_service::consume_spat,this, this->_spat_consumer, this->spat_ptr);
         // Running in parallel
@@ -179,7 +182,7 @@ namespace signal_opt_service
             sleep(sleep_secs);
             attempt_count++;
         }
-        // If failed to update the intersecstd::stringtion information after certain numbers of attempts
+        // If failed to update the intersection information after certain numbers of attempts
         SPDLOG_ERROR("Updating Intersection information failed. ");
         return false;
     }

--- a/signal_opt_service/src/signal_opt_service.cpp
+++ b/signal_opt_service/src/signal_opt_service.cpp
@@ -15,8 +15,8 @@ namespace signal_opt_service
             _spat_group_id = streets_service::streets_configuration::get_string_config("spat_group_id");
             _vsi_topic_name = streets_service::streets_configuration::get_string_config("vsi_consumer_topic");
             _vsi_group_id = streets_service::streets_configuration::get_string_config("vsi_group_id");
-            _tsc_config_topic_name = streets_service::streets_configuration::get_string_config("vsi_consumer_topic");
-            _tsc_config_group_id = streets_service::streets_configuration::get_string_config("vsi_group_id");
+            _tsc_config_topic_name = streets_service::streets_configuration::get_string_config("tsc_config_consumer_topic");
+            _tsc_config_group_id = streets_service::streets_configuration::get_string_config("tsc_config_group_id");
 
             _spat_consumer = client->create_consumer(_bootstrap_server, _spat_topic_name, _spat_group_id);
             _vsi_consumer = client->create_consumer(_bootstrap_server, _vsi_topic_name, _vsi_group_id);

--- a/signal_opt_service/test/test_signal_opt_messages_worker.cpp
+++ b/signal_opt_service/test/test_signal_opt_messages_worker.cpp
@@ -61,7 +61,7 @@ TEST(signal_opt_messages_worker, update_spat)
 TEST(signal_opt_messages_worker, update_tsc_config) {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
     std::string tsc_config_payload = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[1,3,5],\"states\":[{\"movement_name\":\"Right Turn\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":0,\"min_end_time\":0,\"max_end_time\":0,\"likely_time\":0,\"confidence\":0},\"speeds\":[{\"type\":0,\"speed_limit\":4,\"speed_confidence\":1,\"distance\":5,\"class\":5}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
-    ASSERT_FALSE(so_msgs_worker_ptr->update_spat(spat_payload));
+    ASSERT_FALSE(so_msgs_worker_ptr->update_tsc_config(tsc_config_payload));
     tsc_config_payload = "{"
         "\"tsc_config_list\":["                       
         "{"                                       
@@ -83,6 +83,27 @@ TEST(signal_opt_messages_worker, update_tsc_config) {
         "},"
         "}";
 
+    ASSERT_TRUE( so_msgs_worker_ptr->update_tsc_config(tsc_config_payload));
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list.size(),3);
+    // First Entry
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].signal_group_id,1);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].yellow_change_duration,1000);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].red_clearance,500);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].concurrent_signal_groups.size(),2);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].concurrent_signal_groups[0],5);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].concurrent_signal_groups[1],6);
+    // Second Entry
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].signal_group_id,2);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].yellow_change_duration,2000);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].red_clearance,300);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].concurrent_signal_groups.size(),2);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].concurrent_signal_groups[0],5);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].concurrent_signal_groups[1],6);
+    // Third Entry
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].signal_group_id,7);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].yellow_change_duration,2000);
+    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].red_clearance,300);
+    ASSERT_TRUE( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].concurrent_signal_groups.empty()); 
 }
 
 TEST(signal_opt_messages_worker, get_intersection_info_ptr)

--- a/signal_opt_service/test/test_signal_opt_messages_worker.cpp
+++ b/signal_opt_service/test/test_signal_opt_messages_worker.cpp
@@ -80,7 +80,7 @@ TEST(signal_opt_messages_worker, update_tsc_config) {
         "    \"signal_group_id\": 7,"
         "    \"yellow_change_duration\":2000,"
         "    \"red_clearance\":300"
-        "},"
+        "}]"
         "}";
 
     ASSERT_TRUE( so_msgs_worker_ptr->update_tsc_config(tsc_config_payload));

--- a/signal_opt_service/test/test_signal_opt_messages_worker.cpp
+++ b/signal_opt_service/test/test_signal_opt_messages_worker.cpp
@@ -9,15 +9,12 @@ TEST(signal_opt_messages_worker, update_vehicle_list)
     auto vehicle_list_ptr =  std::make_shared<streets_vehicles::vehicle_list>();
     vehicle_list_ptr->set_processor(std::make_shared<streets_vehicles::signalized_status_intent_processor>());
     // Add vehicles
-    SPDLOG_INFO("Initialize! {0}");
 
     ASSERT_TRUE( vehicle_list_ptr->get_vehicles().empty());
-    SPDLOG_INFO("Assert empty list!");
     auto cur_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() + 1000;
     // Valid payload
     std::string vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-507\", \"v_length\": 5, \"min_gap\": 10.0, \"react_t\": 1.5, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
     so_msgs_worker_ptr->update_vehicle_list(vsi_payload, vehicle_list_ptr);
-    SPDLOG_INFO("Populated vehicle list");
     ASSERT_EQ(1, vehicle_list_ptr->get_vehicles().size());
 
     cur_time += 1000;

--- a/signal_opt_service/test/test_signal_opt_messages_worker.cpp
+++ b/signal_opt_service/test/test_signal_opt_messages_worker.cpp
@@ -6,53 +6,60 @@
 TEST(signal_opt_messages_worker, update_vehicle_list)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
+    auto vehicle_list_ptr =  std::make_shared<streets_vehicles::vehicle_list>();
+    vehicle_list_ptr->set_processor(std::make_shared<streets_vehicles::signalized_status_intent_processor>());
     // Add vehicles
-    ASSERT_EQ(0, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
+    SPDLOG_INFO("Initialize! {0}");
+
+    ASSERT_TRUE( vehicle_list_ptr->get_vehicles().empty());
+    SPDLOG_INFO("Assert empty list!");
     auto cur_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() + 1000;
     // Valid payload
     std::string vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-507\", \"v_length\": 5, \"min_gap\": 10.0, \"react_t\": 1.5, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
-    ASSERT_EQ(1, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload, vehicle_list_ptr);
+    SPDLOG_INFO("Populated vehicle list");
+    ASSERT_EQ(1, vehicle_list_ptr->get_vehicles().size());
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-508\", \"v_length\": 5, \"min_gap\": 10.0, \"react_t\": 1.5, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
-    ASSERT_EQ(2, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload, vehicle_list_ptr);
+    ASSERT_EQ(2, vehicle_list_ptr->get_vehicles().size());
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-509\", \"v_length\": 5, \"min_gap\": 10.0, \"react_t\": 1.5, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
-    ASSERT_EQ(3, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload, vehicle_list_ptr);
+    ASSERT_EQ(3, vehicle_list_ptr->get_vehicles().size());
 
     // Update vehicles
-    ASSERT_EQ(5, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().at("DOT-507")._cur_speed / 0.02);
-    ASSERT_EQ(5, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().at("DOT-508")._cur_speed / 0.02);
+    ASSERT_EQ(5, vehicle_list_ptr->get_vehicles().at("DOT-507")._cur_speed / 0.02);
+    ASSERT_EQ(5, vehicle_list_ptr->get_vehicles().at("DOT-508")._cur_speed / 0.02);
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-507\", \"v_length\": 5, \"min_gap\": 15.0, \"react_t\": 2, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 10.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload, vehicle_list_ptr);
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-508\", \"v_length\": 5, \"min_gap\": 15.0, \"react_t\": 2, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 20.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
-    ASSERT_EQ(3, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload, vehicle_list_ptr);
+    ASSERT_EQ(3, vehicle_list_ptr->get_vehicles().size());
 
-    ASSERT_EQ(10, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles()["DOT-507"]._cur_speed / 0.02);
-    ASSERT_EQ(20, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles()["DOT-508"]._cur_speed / 0.02);
+    ASSERT_EQ(10, vehicle_list_ptr->get_vehicles()["DOT-507"]._cur_speed / 0.02);
+    ASSERT_EQ(20, vehicle_list_ptr->get_vehicles()["DOT-508"]._cur_speed / 0.02);
 }
 
 TEST(signal_opt_messages_worker, request_intersection_info)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto intersection_info_ptr = so_msgs_worker_ptr->get_intersection_info_ptr();
+    auto intersection_info_ptr = std::make_shared<OpenAPI::OAIIntersection_info>();
     ASSERT_TRUE(intersection_info_ptr != nullptr);
     ASSERT_EQ(0, intersection_info_ptr->getLinkLanelets().size());
-    ASSERT_FALSE(so_msgs_worker_ptr->request_intersection_info());
+    ASSERT_FALSE(so_msgs_worker_ptr->request_intersection_info(intersection_info_ptr));
 }
 
 TEST(signal_opt_messages_worker, update_spat)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
+    auto spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
     // Invalid payload
     std::string spat_payload ="{"
         "\"tsc_config_list\":["                       
@@ -74,18 +81,20 @@ TEST(signal_opt_messages_worker, update_spat)
         "    \"red_clearance\":300"
         "}]"
         "}";
-    ASSERT_FALSE(so_msgs_worker_ptr->update_spat(spat_payload));
+    ASSERT_FALSE(so_msgs_worker_ptr->update_spat(spat_payload, spat_ptr));
     spat_payload = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[1,3,5],\"states\":[{\"movement_name\":\"Right Turn\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":0,\"min_end_time\":0,\"max_end_time\":0,\"likely_time\":0,\"confidence\":0},\"speeds\":[{\"type\":0,\"speed_limit\":4,\"speed_confidence\":1,\"distance\":5,\"class\":5}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
-    ASSERT_TRUE(so_msgs_worker_ptr->update_spat(spat_payload));
-    ASSERT_EQ(1909, so_msgs_worker_ptr->get_spat_ptr()->intersections.front().id);
-    ASSERT_EQ("West Intersection", so_msgs_worker_ptr->get_spat_ptr()->intersections.front().name);
+    ASSERT_TRUE(so_msgs_worker_ptr->update_spat(spat_payload, spat_ptr));
+    ASSERT_EQ(1909, spat_ptr->intersections.front().id);
+    ASSERT_EQ("West Intersection",spat_ptr->intersections.front().name);
 }
 
 TEST(signal_opt_messages_worker, update_tsc_config) {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
+    auto tsc_config_ptr = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
     // Invalid payload
     std::string tsc_config_payload = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[1,3,5],\"states\":[{\"movement_name\":\"Right Turn\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":0,\"min_end_time\":0,\"max_end_time\":0,\"likely_time\":0,\"confidence\":0},\"speeds\":[{\"type\":0,\"speed_limit\":4,\"speed_confidence\":1,\"distance\":5,\"class\":5}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
-    ASSERT_FALSE(so_msgs_worker_ptr->update_tsc_config(tsc_config_payload));
+    ASSERT_FALSE(so_msgs_worker_ptr->update_tsc_config(tsc_config_payload, tsc_config_ptr));
+    ASSERT_FALSE( tsc_config_ptr == nullptr);
     // Valid payload
     tsc_config_payload = "{"
         "\"tsc_config_list\":["                       
@@ -108,49 +117,25 @@ TEST(signal_opt_messages_worker, update_tsc_config) {
         "}]"
         "}";
 
-    ASSERT_TRUE( so_msgs_worker_ptr->update_tsc_config(tsc_config_payload));
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list.size(),3);
+    ASSERT_TRUE( so_msgs_worker_ptr->update_tsc_config(tsc_config_payload, tsc_config_ptr));
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list.size(),3);
     // First Entry
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].signal_group_id,1);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].yellow_change_duration,1000);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].red_clearance,500);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].concurrent_signal_groups.size(),2);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].concurrent_signal_groups[0],5);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[0].concurrent_signal_groups[1],6);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[0].signal_group_id,1);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[0].yellow_change_duration,1000);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[0].red_clearance,500);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[0].concurrent_signal_groups.size(),2);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[0].concurrent_signal_groups[0],5);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[0].concurrent_signal_groups[1],6);
     // Second Entry
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].signal_group_id,2);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].yellow_change_duration,2000);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].red_clearance,300);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].concurrent_signal_groups.size(),2);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].concurrent_signal_groups[0],5);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[1].concurrent_signal_groups[1],6);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[1].signal_group_id,2);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[1].yellow_change_duration,2000);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[1].red_clearance,300);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[1].concurrent_signal_groups.size(),2);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[1].concurrent_signal_groups[0],5);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[1].concurrent_signal_groups[1],6);
     // Third Entry
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].signal_group_id,7);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].yellow_change_duration,2000);
-    ASSERT_EQ( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].red_clearance,300);
-    ASSERT_TRUE( so_msgs_worker_ptr->get_tsc_config_ptr()->tsc_config_list[2].concurrent_signal_groups.empty()); 
-}
-
-TEST(signal_opt_messages_worker, get_intersection_info_ptr)
-{
-    auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto intersection_info_ptr = so_msgs_worker_ptr->get_intersection_info_ptr();
-    ASSERT_TRUE(intersection_info_ptr != nullptr);
-    ASSERT_EQ(0, intersection_info_ptr->getLinkLanelets().size());
-}
-
-TEST(signal_opt_messages_worker, get_vehicle_list_ptr)
-{
-    auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto vehicle_list_ptr = so_msgs_worker_ptr->get_vehicle_list_ptr();
-    ASSERT_TRUE(vehicle_list_ptr != nullptr);
-    ASSERT_EQ(0, vehicle_list_ptr->get_vehicles().size());
-}
-
-TEST(signal_opt_messages_worker, get_spat_ptr)
-{
-    auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto spat_ptr = so_msgs_worker_ptr->get_spat_ptr();
-    ASSERT_TRUE(spat_ptr != nullptr);
-    ASSERT_EQ(0, spat_ptr->intersections.size());
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[2].signal_group_id,7);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[2].yellow_change_duration,2000);
+    ASSERT_EQ( tsc_config_ptr->tsc_config_list[2].red_clearance,300);
+    ASSERT_TRUE( tsc_config_ptr->tsc_config_list[2].concurrent_signal_groups.empty()); 
 }

--- a/signal_opt_service/test/test_signal_opt_messages_worker.cpp
+++ b/signal_opt_service/test/test_signal_opt_messages_worker.cpp
@@ -84,8 +84,8 @@ TEST(signal_opt_messages_worker, update_spat)
     ASSERT_FALSE(so_msgs_worker_ptr->update_spat(spat_payload, spat_ptr));
     spat_payload = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[1,3,5],\"states\":[{\"movement_name\":\"Right Turn\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":0,\"min_end_time\":0,\"max_end_time\":0,\"likely_time\":0,\"confidence\":0},\"speeds\":[{\"type\":0,\"speed_limit\":4,\"speed_confidence\":1,\"distance\":5,\"class\":5}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
     ASSERT_TRUE(so_msgs_worker_ptr->update_spat(spat_payload, spat_ptr));
-    ASSERT_EQ(1909, spat_ptr->intersections.front().id);
-    ASSERT_EQ("West Intersection",spat_ptr->intersections.front().name);
+    ASSERT_EQ(1909, spat_ptr->get_intersection().id);
+    ASSERT_EQ("West Intersection",spat_ptr->get_intersection().name);
 }
 
 TEST(signal_opt_messages_worker, update_tsc_config) {

--- a/signal_opt_service/test/test_signal_opt_messages_worker.cpp
+++ b/signal_opt_service/test/test_signal_opt_messages_worker.cpp
@@ -3,47 +3,47 @@
 
 #include "signal_opt_messages_worker.h"
 
-TEST(signal_opt_messages_worker, add_update_vehicle)
+TEST(signal_opt_messages_worker, update_vehicle_list)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
     // Add vehicles
-    ASSERT_EQ(0, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().size());
+    ASSERT_EQ(0, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
     auto cur_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count() + 1000;
     std::string vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-507\", \"v_length\": 5, \"min_gap\": 10.0, \"react_t\": 1.5, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->add_update_vehicle(vsi_payload);
-    ASSERT_EQ(1, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
+    ASSERT_EQ(1, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-508\", \"v_length\": 5, \"min_gap\": 10.0, \"react_t\": 1.5, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->add_update_vehicle(vsi_payload);
-    ASSERT_EQ(2, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
+    ASSERT_EQ(2, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-509\", \"v_length\": 5, \"min_gap\": 10.0, \"react_t\": 1.5, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 5.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->add_update_vehicle(vsi_payload);
-    ASSERT_EQ(3, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
+    ASSERT_EQ(3, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
 
     // Update vehicles
-    ASSERT_EQ(5, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().at("DOT-507")._cur_speed / 0.02);
-    ASSERT_EQ(5, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().at("DOT-508")._cur_speed / 0.02);
+    ASSERT_EQ(5, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().at("DOT-507")._cur_speed / 0.02);
+    ASSERT_EQ(5, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().at("DOT-508")._cur_speed / 0.02);
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-507\", \"v_length\": 5, \"min_gap\": 15.0, \"react_t\": 2, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 10.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->add_update_vehicle(vsi_payload);
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-508\", \"v_length\": 5, \"min_gap\": 15.0, \"react_t\": 2, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 20.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
-    so_msgs_worker_ptr->add_update_vehicle(vsi_payload);
-    ASSERT_EQ(3, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().size());
+    so_msgs_worker_ptr->update_vehicle_list(vsi_payload);
+    ASSERT_EQ(3, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles().size());
 
-    ASSERT_EQ(10, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles()["DOT-507"]._cur_speed / 0.02);
-    ASSERT_EQ(20, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles()["DOT-508"]._cur_speed / 0.02);
+    ASSERT_EQ(10, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles()["DOT-507"]._cur_speed / 0.02);
+    ASSERT_EQ(20, so_msgs_worker_ptr->get_vehicle_list_ptr()->get_vehicles()["DOT-508"]._cur_speed / 0.02);
 }
 
 TEST(signal_opt_messages_worker, request_intersection_info)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto intersection_info_ptr = so_msgs_worker_ptr->get_intersection_info();
+    auto intersection_info_ptr = so_msgs_worker_ptr->get_intersection_info_ptr();
     ASSERT_TRUE(intersection_info_ptr != nullptr);
     ASSERT_EQ(0, intersection_info_ptr->getLinkLanelets().size());
     ASSERT_FALSE(so_msgs_worker_ptr->request_intersection_info());
@@ -54,30 +54,57 @@ TEST(signal_opt_messages_worker, update_spat)
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
     std::string spat_payload = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[1,3,5],\"states\":[{\"movement_name\":\"Right Turn\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":0,\"min_end_time\":0,\"max_end_time\":0,\"likely_time\":0,\"confidence\":0},\"speeds\":[{\"type\":0,\"speed_limit\":4,\"speed_confidence\":1,\"distance\":5,\"class\":5}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
     ASSERT_TRUE(so_msgs_worker_ptr->update_spat(spat_payload));
-    ASSERT_EQ(1909, so_msgs_worker_ptr->get_latest_spat()->intersections.front().id);
-    ASSERT_EQ("West Intersection", so_msgs_worker_ptr->get_latest_spat()->intersections.front().name);
+    ASSERT_EQ(1909, so_msgs_worker_ptr->get_spat_ptr()->intersections.front().id);
+    ASSERT_EQ("West Intersection", so_msgs_worker_ptr->get_spat_ptr()->intersections.front().name);
 }
 
-TEST(signal_opt_messages_worker, get_intersection_info)
+TEST(signal_opt_messages_worker, update_tsc_config) {
+    auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
+    std::string tsc_config_payload = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[1,3,5],\"states\":[{\"movement_name\":\"Right Turn\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":0,\"min_end_time\":0,\"max_end_time\":0,\"likely_time\":0,\"confidence\":0},\"speeds\":[{\"type\":0,\"speed_limit\":4,\"speed_confidence\":1,\"distance\":5,\"class\":5}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
+    ASSERT_FALSE(so_msgs_worker_ptr->update_spat(spat_payload));
+    tsc_config_payload = "{"
+        "\"tsc_config_list\":["                       
+        "{"                                       
+        "    \"signal_group_id\": 1,"              
+        "    \"yellow_change_duration\":1000,"    
+        "    \"red_clearance\":500,"              
+        "    \"concurrent_signal_groups\":[5,6]"  
+        "},"                                      
+        "{"                                          
+        "    \"signal_group_id\": 2,"
+        "    \"yellow_change_duration\":2000,"
+        "    \"red_clearance\":300,"
+        "    \"concurrent_signal_groups\":[5,6]"
+        "},"
+        "{"
+        "    \"signal_group_id\": 7,"
+        "    \"yellow_change_duration\":2000,"
+        "    \"red_clearance\":300"
+        "},"
+        "}";
+
+}
+
+TEST(signal_opt_messages_worker, get_intersection_info_ptr)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto intersection_info_ptr = so_msgs_worker_ptr->get_intersection_info();
+    auto intersection_info_ptr = so_msgs_worker_ptr->get_intersection_info_ptr();
     ASSERT_TRUE(intersection_info_ptr != nullptr);
     ASSERT_EQ(0, intersection_info_ptr->getLinkLanelets().size());
 }
 
-TEST(signal_opt_messages_worker, get_vehicle_list)
+TEST(signal_opt_messages_worker, get_vehicle_list_ptr)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto vehicle_list_ptr = so_msgs_worker_ptr->get_vehicle_list();
+    auto vehicle_list_ptr = so_msgs_worker_ptr->get_vehicle_list_ptr();
     ASSERT_TRUE(vehicle_list_ptr != nullptr);
-    ASSERT_EQ(0, so_msgs_worker_ptr->get_vehicle_list()->get_vehicles().size());
+    ASSERT_EQ(0, vehicle_list_ptr->get_vehicles().size());
 }
 
-TEST(signal_opt_messages_worker, get_latest_spat)
+TEST(signal_opt_messages_worker, get_spat_ptr)
 {
     auto so_msgs_worker_ptr = std::make_shared<signal_opt_service::signal_opt_messages_worker>();
-    auto spat_ptr = so_msgs_worker_ptr->get_latest_spat();
+    auto spat_ptr = so_msgs_worker_ptr->get_spat_ptr();
     ASSERT_TRUE(spat_ptr != nullptr);
     ASSERT_EQ(0, spat_ptr->intersections.size());
 }

--- a/signal_opt_service/test/test_signal_opt_service.cpp
+++ b/signal_opt_service/test/test_signal_opt_service.cpp
@@ -7,6 +7,7 @@ TEST(signal_opt_service, initialize)
 {
     signal_opt_service::signal_opt_service so_service;
     ASSERT_FALSE(so_service.initialize());
+    
 }
 
 TEST(signal_opt_service, update_intersection_info)

--- a/signal_opt_service/test/test_signal_opt_service.cpp
+++ b/signal_opt_service/test/test_signal_opt_service.cpp
@@ -3,6 +3,7 @@
 
 #include "signal_opt_service.h"
 #include "mock_kafka_consumer_worker.h"
+#include "movement_group.h"
 
 using testing::_;
 using testing::Return;
@@ -26,12 +27,13 @@ TEST(signal_opt_service, consume_spat) {
     signal_opt_service::signal_opt_service so_service;
     std::shared_ptr<kafka_clients::mock_kafka_consumer_worker> mock_spat_consumer = std::make_shared<kafka_clients::mock_kafka_consumer_worker>();
     std::shared_ptr<signal_phase_and_timing::spat> spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
-    EXPECT_CALL(*mock_spat_consumer,is_running()).Times(5).WillOnce(Return(false))
+    EXPECT_CALL(*mock_spat_consumer,is_running()).Times(6).WillOnce(Return(false))
                                                             .WillOnce(Return(true))
                                                             .WillOnce(Return(false))
                                                             .WillOnce(Return(true))
+                                                            .WillOnce(Return(true))
                                                             .WillRepeatedly(Return(false));
-    EXPECT_CALL(*mock_spat_consumer, consume(1000)).Times(2).WillOnce(Return("")).WillRepeatedly(Return(
+    EXPECT_CALL(*mock_spat_consumer, consume(1000)).Times(3).WillOnce(Return("")).WillOnce(Return("Not JSON")).WillRepeatedly(Return(
         "{"
             "\"timestamp\":0,"
             "\"name\":\"West Intersection\","
@@ -73,9 +75,9 @@ TEST(signal_opt_service, consume_tsc_config) {
     signal_opt_service::signal_opt_service so_service;
     std::shared_ptr<kafka_clients::mock_kafka_consumer_worker> mock_tsc_config_consumer = std::make_shared<kafka_clients::mock_kafka_consumer_worker>();
     std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
-    EXPECT_CALL(*mock_tsc_config_consumer,is_running()).Times(3).WillOnce(Return(false))
+    EXPECT_CALL(*mock_tsc_config_consumer,is_running()).Times(4).WillOnce(Return(false))
                                                             .WillRepeatedly(Return(true));
-    EXPECT_CALL(*mock_tsc_config_consumer, consume(1000)).Times(2).WillOnce(Return("")).WillRepeatedly(Return(
+    EXPECT_CALL(*mock_tsc_config_consumer, consume(1000)).Times(3).WillOnce(Return("")).WillOnce(Return("Not JSON")).WillRepeatedly(Return(
         "{"
         "\"tsc_config_list\":["                       
         "{"                                       
@@ -103,5 +105,120 @@ TEST(signal_opt_service, consume_tsc_config) {
     // mock_spat_consumer returns "" from consume(1000)
     so_service.consume_tsc_config(mock_tsc_config_consumer, tsc_config);
    
+}
+
+TEST(signal_opt_service, consume_vsi) {
+    signal_opt_service::signal_opt_service so_service;
+    std::shared_ptr<kafka_clients::mock_kafka_consumer_worker> mock_vsi_consumer = std::make_shared<kafka_clients::mock_kafka_consumer_worker>();
+    std::shared_ptr<streets_vehicles::vehicle_list> vehicle_list = std::make_shared<streets_vehicles::vehicle_list>();
+    auto status_intent_processor = std::make_shared<streets_vehicles::signalized_status_intent_processor>();
+    vehicle_list->set_processor(status_intent_processor);
+    auto cur_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    EXPECT_CALL(*mock_vsi_consumer,is_running()).Times(5).WillOnce(Return(false))
+                                                        .WillOnce(Return(true))
+                                                        .WillOnce(Return(true))
+                                                        .WillOnce(Return(true))
+                                                        .WillRepeatedly(Return(false));
+    EXPECT_CALL(*mock_vsi_consumer, consume(1000)).Times(3)
+            .WillOnce(Return(""))
+            .WillOnce(Return("Not JSON"))
+            .WillRepeatedly(Return(
+                "{ \"metadata\":"
+                    "{ \"timestamp\": 1664375832148 },"
+                "\"payload\": "
+                    "{"
+                        "\"v_id\": \"DOT-507\","
+                        "\"v_length\": 5," 
+                        "\"min_gap\": 15.0,"
+                        "\"react_t\": 2,"
+                        "\"max_accel\": 5.0,"
+                        "\"max_decel\": 5.0,"
+                        "\"cur_speed\": 10.0," 
+                        "\"cur_accel\": 0.0," 
+                        "\"cur_lane_id\": 7," 
+                        "\"cur_ds\": 7.0," 
+                        "\"direction\": \"straight\","
+                        "\"entry_lane_id\": 7,"
+                        "\"link_lane_id\": 8," 
+                        "\"dest_lane_id\": 9,"
+                        "\"is_allowed\": false," 
+                        "\"depart_pos\": 1," 
+                        "\"est_paths\":" 
+                            "["
+                                "{" 
+                                    "\"ts\": 1623677096200,"
+                                    "\"id\": 7,"
+                                    "\"ds\": 6.0"
+                                "}," 
+                                "{" 
+                                    "\"ts\": 1623677096400,"
+                                    "\"id\": 7," 
+                                    "\"ds\": 5.0" 
+                                "}," 
+                                "{" 
+                                    "\"ts\": 1623677096600," 
+                                    "\"id\": 7,"
+                                    "\"ds\": 4.0" 
+                                "}," 
+                                "{" 
+                                    "\"ts\": 1623677096800," 
+                                    "\"id\": 7," 
+                                    "\"ds\": 3.0" 
+                                "}," 
+                                "{" 
+                                    "\"ts\": 1623677097000,"
+                                    "\"id\": 7,"
+                                    "\"ds\": 2.0"
+                                "}" 
+                            "]" 
+                    "}"
+                "}"));
+    so_service.consume_vsi(mock_vsi_consumer, vehicle_list);
+    so_service.consume_vsi(mock_vsi_consumer, vehicle_list);
+}
+
+TEST(signal_opt_service, populate_movement_group) {
+    signal_opt_service::signal_opt_service so_service;
+    auto tsc_config = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
+    auto m_groups = std::make_shared<signal_opt_service::movement_groups>();
+    streets_tsc_configuration::signal_group_configuration sig5;
+    sig5.signal_group_id = 5;
+    sig5.yellow_change_duration = 3000;
+    sig5.red_clearance = 2000;
+    sig5.concurrent_signal_groups.push_back(6);
+    tsc_config->tsc_config_list.push_back(sig5);
+
+    streets_tsc_configuration::signal_group_configuration sig2;
+    sig2.signal_group_id = 2;
+    sig2.yellow_change_duration = 3000;
+    sig2.red_clearance = 2000;
+    sig2.concurrent_signal_groups.push_back(4);
+    tsc_config->tsc_config_list.push_back(sig2);
+
+    streets_tsc_configuration::signal_group_configuration sig6;
+    sig6.signal_group_id = 6;
+    sig6.yellow_change_duration = 3000;
+    sig6.red_clearance = 2000;
+    sig6.concurrent_signal_groups.push_back(5);
+    tsc_config->tsc_config_list.push_back(sig6);
+
+
+    streets_tsc_configuration::signal_group_configuration sig4;
+    sig4.signal_group_id = 4;
+    sig4.yellow_change_duration = 3000;
+    sig4.red_clearance = 2000;
+    sig4.concurrent_signal_groups.push_back(2);
+    tsc_config->tsc_config_list.push_back(sig4);
+
+    so_service.populate_movement_groups(m_groups,tsc_config);
+
+    
+    ASSERT_EQ(2, m_groups->groups.size());
+    ASSERT_EQ(5, m_groups->groups.front().signal_groups.first);
+    ASSERT_EQ(6, m_groups->groups.front().signal_groups.second);
+
+    ASSERT_EQ(2, m_groups->groups.back().signal_groups.first);
+    ASSERT_EQ(4, m_groups->groups.back().signal_groups.second);
+
 
 }

--- a/signal_opt_service/test/test_signal_opt_service.cpp
+++ b/signal_opt_service/test/test_signal_opt_service.cpp
@@ -242,3 +242,191 @@ TEST(signal_opt_service, populate_movement_group) {
 
 
 }
+
+/**
+ * @brief Test populate movement group method with example tsc configurations state.
+ */
+TEST(signal_opt_service, populate_movement_group_no_concurrent_sg) {
+    signal_opt_service::signal_opt_service so_service;
+    auto tsc_config = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
+    auto m_groups = std::make_shared<signal_opt_service::movement_groups>();
+    streets_tsc_configuration::signal_group_configuration sig5;
+    sig5.signal_group_id = 5;
+    sig5.yellow_change_duration = 3000;
+    sig5.red_clearance = 2000;
+    tsc_config->tsc_config_list.push_back(sig5);
+
+    streets_tsc_configuration::signal_group_configuration sig2;
+    sig2.signal_group_id = 2;
+    sig2.yellow_change_duration = 3000;
+    sig2.red_clearance = 2000;
+    sig2.concurrent_signal_groups.push_back(4);
+    tsc_config->tsc_config_list.push_back(sig2);
+
+    streets_tsc_configuration::signal_group_configuration sig6;
+    sig6.signal_group_id = 6;
+    sig6.yellow_change_duration = 3000;
+    sig6.red_clearance = 2000;
+    tsc_config->tsc_config_list.push_back(sig6);
+
+
+    streets_tsc_configuration::signal_group_configuration sig4;
+    sig4.signal_group_id = 4;
+    sig4.yellow_change_duration = 3000;
+    sig4.red_clearance = 2000;
+    sig4.concurrent_signal_groups.push_back(2);
+    tsc_config->tsc_config_list.push_back(sig4);
+
+    // TSC Configuration
+    // barrier = ||
+    //ring 1 : 2 || 5 6
+    //ring 2 : 4 || 
+    so_service.populate_movement_groups(m_groups,tsc_config);
+    
+    ASSERT_EQ(3, m_groups->groups.size());
+    auto mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(5, mg.signal_groups.first);
+    ASSERT_EQ(0, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(2, mg.signal_groups.first);
+    ASSERT_EQ(4, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(6, mg.signal_groups.first);
+    ASSERT_EQ(0, mg.signal_groups.second);
+}
+
+/**
+ * @brief Test populate movement group method with example tsc configurations state.
+ */
+TEST(signal_opt_service, populate_movement_group_nema) {
+    signal_opt_service::signal_opt_service so_service;
+    auto tsc_config = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
+    auto m_groups = std::make_shared<signal_opt_service::movement_groups>();
+    streets_tsc_configuration::signal_group_configuration sig1;
+    sig1.signal_group_id = 1;
+    sig1.yellow_change_duration = 3000;
+    sig1.red_clearance = 2000;
+    sig1.concurrent_signal_groups.push_back(5);
+    sig1.concurrent_signal_groups.push_back(6);
+
+    tsc_config->tsc_config_list.push_back(sig1);
+
+    streets_tsc_configuration::signal_group_configuration sig2;
+    sig2.signal_group_id = 2;
+    sig2.yellow_change_duration = 3000;
+    sig2.red_clearance = 2000;
+    sig2.concurrent_signal_groups.push_back(5);
+    sig2.concurrent_signal_groups.push_back(6);
+    tsc_config->tsc_config_list.push_back(sig2);
+
+    streets_tsc_configuration::signal_group_configuration sig3;
+    sig3.signal_group_id = 3;
+    sig3.yellow_change_duration = 3000;
+    sig3.red_clearance = 2000;
+    sig3.concurrent_signal_groups.push_back(7);
+    sig3.concurrent_signal_groups.push_back(8);
+    tsc_config->tsc_config_list.push_back(sig3);
+
+    streets_tsc_configuration::signal_group_configuration sig4;
+    sig4.signal_group_id = 4;
+    sig4.yellow_change_duration = 3000;
+    sig4.red_clearance = 2000;
+    sig4.concurrent_signal_groups.push_back(7);
+    sig4.concurrent_signal_groups.push_back(8);
+    tsc_config->tsc_config_list.push_back(sig4);
+
+    streets_tsc_configuration::signal_group_configuration sig5;
+    sig5.signal_group_id = 5;
+    sig5.yellow_change_duration = 3000;
+    sig5.red_clearance = 2000;
+    sig5.concurrent_signal_groups.push_back(1);
+    sig5.concurrent_signal_groups.push_back(2);
+    tsc_config->tsc_config_list.push_back(sig5);
+
+    streets_tsc_configuration::signal_group_configuration sig6;
+    sig6.signal_group_id = 6;
+    sig6.yellow_change_duration = 3000;
+    sig6.red_clearance = 2000;
+    sig6.concurrent_signal_groups.push_back(1);
+    sig6.concurrent_signal_groups.push_back(2);
+    tsc_config->tsc_config_list.push_back(sig6);
+
+    streets_tsc_configuration::signal_group_configuration sig7;
+    sig7.signal_group_id = 7;
+    sig7.yellow_change_duration = 3000;
+    sig7.red_clearance = 2000;
+    sig7.concurrent_signal_groups.push_back(3);
+    sig7.concurrent_signal_groups.push_back(4);
+    tsc_config->tsc_config_list.push_back(sig7);
+
+    streets_tsc_configuration::signal_group_configuration sig8;
+    sig8.signal_group_id = 8;
+    sig8.yellow_change_duration = 3000;
+    sig8.red_clearance = 2000;
+    sig8.concurrent_signal_groups.push_back(3);
+    sig8.concurrent_signal_groups.push_back(4);
+    tsc_config->tsc_config_list.push_back(sig8);
+
+    // TSC Configuration
+    // barrier = ||
+    //ring 1 : 1 2 || 3 4
+    //ring 2 : 5 6 || 7 8 
+    so_service.populate_movement_groups(m_groups,tsc_config);
+    
+    ASSERT_EQ(8, m_groups->groups.size());
+    auto mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(1, mg.signal_groups.first);
+    ASSERT_EQ(5, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(1, mg.signal_groups.first);
+    ASSERT_EQ(6, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(2, mg.signal_groups.first);
+    ASSERT_EQ(5, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(2, mg.signal_groups.first);
+    ASSERT_EQ(6, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(3, mg.signal_groups.first);
+    ASSERT_EQ(7, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(3, mg.signal_groups.first);
+    ASSERT_EQ(8, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(4, mg.signal_groups.first);
+    ASSERT_EQ(7, mg.signal_groups.second);
+
+    mg = m_groups->groups.front();
+    m_groups->groups.pop_front();
+
+    ASSERT_EQ(4, mg.signal_groups.first);
+    ASSERT_EQ(8, mg.signal_groups.second);
+}

--- a/signal_opt_service/test/test_signal_opt_service.cpp
+++ b/signal_opt_service/test/test_signal_opt_service.cpp
@@ -73,7 +73,7 @@ TEST(signal_opt_service, consume_tsc_config) {
     signal_opt_service::signal_opt_service so_service;
     std::shared_ptr<kafka_clients::mock_kafka_consumer_worker> mock_tsc_config_consumer = std::make_shared<kafka_clients::mock_kafka_consumer_worker>();
     std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
-    EXPECT_CALL(*mock_tsc_config_consumer,is_running()).Times(4).WillOnce(Return(false))
+    EXPECT_CALL(*mock_tsc_config_consumer,is_running()).Times(3).WillOnce(Return(false))
                                                             .WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_tsc_config_consumer, consume(1000)).Times(2).WillOnce(Return("")).WillRepeatedly(Return(
         "{"
@@ -102,8 +102,6 @@ TEST(signal_opt_service, consume_tsc_config) {
     SPDLOG_INFO("Consuming Empty message");
     // mock_spat_consumer returns "" from consume(1000)
     so_service.consume_tsc_config(mock_tsc_config_consumer, tsc_config);
-    SPDLOG_INFO("Consuming message.");
-    // mock_spat_consumer returns spat json string from consume(1000)
-    so_service.consume_tsc_config(mock_tsc_config_consumer,tsc_config);
+   
 
 }

--- a/signal_opt_service/test/test_signal_opt_service.cpp
+++ b/signal_opt_service/test/test_signal_opt_service.cpp
@@ -2,6 +2,11 @@
 #include <spdlog/spdlog.h>
 
 #include "signal_opt_service.h"
+#include "mock_kafka_consumer_worker.h"
+
+using testing::_;
+using testing::Return;
+
 
 TEST(signal_opt_service, initialize)
 {
@@ -15,4 +20,90 @@ TEST(signal_opt_service, update_intersection_info)
     signal_opt_service::signal_opt_service so_service;
     ASSERT_FALSE(so_service.initialize());
     ASSERT_FALSE(so_service.update_intersection_info(1000, 1));
+}
+
+TEST(signal_opt_service, consume_spat) {
+    signal_opt_service::signal_opt_service so_service;
+    std::shared_ptr<kafka_clients::mock_kafka_consumer_worker> mock_spat_consumer = std::make_shared<kafka_clients::mock_kafka_consumer_worker>();
+    std::shared_ptr<signal_phase_and_timing::spat> spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
+    EXPECT_CALL(*mock_spat_consumer,is_running()).Times(5).WillOnce(Return(false))
+                                                            .WillOnce(Return(true))
+                                                            .WillOnce(Return(false))
+                                                            .WillOnce(Return(true))
+                                                            .WillRepeatedly(Return(false));
+    EXPECT_CALL(*mock_spat_consumer, consume(1000)).Times(2).WillOnce(Return("")).WillRepeatedly(Return(
+        "{"
+            "\"timestamp\":0,"
+            "\"name\":\"West Intersection\","
+            "\"intersections\":["
+            "{"
+                "\"name\":\"West Intersection\","
+                "\"id\":1909,"
+                "\"status\":0,"
+                "\"revision\":123,"
+                "\"moy\":34232,"
+                "\"time_stamp\":130,"
+                "\"enabled_lanes\":[1,3,5],"
+                "\"states\":["
+                    "{"
+                        "\"movement_name\":\"Right Turn\","
+                        "\"signal_group\":4,"
+                        "\"state_time_speed\":["
+                            "{"
+                                "\"event_state\":3,"
+                                "\"timing\":{\"start_time\":0,\"min_end_time\":0,\"max_end_time\":0,\"likely_time\":0,\"confidence\":0},"
+                                "\"speeds\":[{\"type\":0,\"speed_limit\":4,\"speed_confidence\":1,\"distance\":5,\"class\":5}]"
+                            "}],"
+                            "\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]"
+                    "}],"
+                "\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}"));
+    // mock_spat_consumer returns false to is_running
+    SPDLOG_INFO("Consuming not running!");
+    so_service.consume_spat(mock_spat_consumer,spat_ptr);
+    SPDLOG_INFO("Consuming Empty message");
+    // mock_spat_consumer returns "" from consume(1000)
+    so_service.consume_spat(mock_spat_consumer, spat_ptr);
+    SPDLOG_INFO("Consuming message.");
+    // mock_spat_consumer returns spat json string from consume(1000)
+    so_service.consume_spat(mock_spat_consumer,spat_ptr);
+
+}
+
+TEST(signal_opt_service, consume_tsc_config) {
+    signal_opt_service::signal_opt_service so_service;
+    std::shared_ptr<kafka_clients::mock_kafka_consumer_worker> mock_tsc_config_consumer = std::make_shared<kafka_clients::mock_kafka_consumer_worker>();
+    std::shared_ptr<streets_tsc_configuration::tsc_configuration_state> tsc_config = std::make_shared<streets_tsc_configuration::tsc_configuration_state>();
+    EXPECT_CALL(*mock_tsc_config_consumer,is_running()).Times(4).WillOnce(Return(false))
+                                                            .WillRepeatedly(Return(true));
+    EXPECT_CALL(*mock_tsc_config_consumer, consume(1000)).Times(2).WillOnce(Return("")).WillRepeatedly(Return(
+        "{"
+        "\"tsc_config_list\":["                       
+        "{"                                       
+        "    \"signal_group_id\": 1,"              
+        "    \"yellow_change_duration\":1000,"    
+        "    \"red_clearance\":500,"              
+        "    \"concurrent_signal_groups\":[5,6]"  
+        "},"                                      
+        "{"                                          
+        "    \"signal_group_id\": 2,"
+        "    \"yellow_change_duration\":2000,"
+        "    \"red_clearance\":300,"
+        "    \"concurrent_signal_groups\":[5,6]"
+        "},"
+        "{"
+        "    \"signal_group_id\": 7,"
+        "    \"yellow_change_duration\":2000,"
+        "    \"red_clearance\":300"
+        "}]"
+        "}"));
+    // mock_spat_consumer returns false to is_running
+    SPDLOG_INFO("Consuming not running!");
+    so_service.consume_tsc_config(mock_tsc_config_consumer,tsc_config);
+    SPDLOG_INFO("Consuming Empty message");
+    // mock_spat_consumer returns "" from consume(1000)
+    so_service.consume_tsc_config(mock_tsc_config_consumer, tsc_config);
+    SPDLOG_INFO("Consuming message.");
+    // mock_spat_consumer returns spat json string from consume(1000)
+    so_service.consume_tsc_config(mock_tsc_config_consumer,tsc_config);
+
 }

--- a/streets_utils/streets_signal_phase_and_timing/CMakeLists.txt
+++ b/streets_utils/streets_signal_phase_and_timing/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.10.2)
 project(streets_signal_phase_and_timing)
                     
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-
-
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(Boost COMPONENTS system filesystem thread REQUIRED)
 find_package(spdlog REQUIRED)

--- a/streets_utils/streets_signal_phase_and_timing/README.md
+++ b/streets_utils/streets_signal_phase_and_timing/README.md
@@ -154,3 +154,13 @@ spat_ptr->update(ntcip_1202_data, _use_msg_timestamp);  // use struct to update 
                                                         // host machine unix time(if false) or NTCIP UDP message timestamp 
                                                         // (if true) 
 ```
+
+## Modifying SPaT Object
+The `spat` object has been made thread safe using a internal `shared_mutex` for **read/write** locking behavior. Currently the lock allows concurrent access for **read** (copy constructor) operatons and exclusive access for **write** (changing `spat` object data) operations. 
+
+All fields of `spat` have been made private so to **read** the data inside the `spat` object use the `get_intersection_state()` method which will return and copy of the internal `intersection_state` object that represents the state of the spat at the time this method is called. Since this is a copy of the current state, it will not remain current with the spat data so this method should be called when the data is being used and should be called repeatedly for any calculations that happen on an interval.
+
+In order to **update** the spat object there are currently **3** methods:
+- `update(ntcip::ntcip_1202_ext &ntcip_data, bool use_ntcip_timestamp)` is used to update spat using ntcip data from the **Traffic Signal Controller (TSC)**.
+- `fromJson(const std::string json)` is used to update spat using a JSON update obtained from kafka.
+- `set_intersection(const intersection_state &intersection)` is used to update the spat using an `intersection_state` object. This method can be used for any updates that need to be made to the spat object that come from other sources.

--- a/streets_utils/streets_signal_phase_and_timing/include/spat.h
+++ b/streets_utils/streets_signal_phase_and_timing/include/spat.h
@@ -12,6 +12,8 @@
 #include <list>
 #include <math.h>
 #include <chrono>
+#include <shared_mutex>
+#include <mutex>
 
 
 namespace signal_phase_and_timing{
@@ -35,11 +37,18 @@ namespace signal_phase_and_timing{
         std::unordered_map<int,int> phase_to_signal_group;
 
         /**
+         * @brief 
+         */
+        std::shared_mutex spat_lock;
+
+        /**
          * @brief Serialize SPaT object to rapidjson::Value for writing as JSON string
          * 
          * @return rapidjson::Value serialize SPaT object
          */
-        std::string toJson() const;
+        std::string toJson();
+
+        intersection_state get_intersection();
         /**
          * @brief Deserialize SPaT JSON into SPaT object.
          * 

--- a/streets_utils/streets_signal_phase_and_timing/include/spat.h
+++ b/streets_utils/streets_signal_phase_and_timing/include/spat.h
@@ -17,106 +17,131 @@
 
 
 namespace signal_phase_and_timing{
-    struct spat{
-        /**
-         * @brief Timestamp in minutes of the UTC year (see J2735 SPaT message documentation for reference).
-         */
-        u_int32_t timestamp = 0;
-        /**
-         * @brief Descriptive name for this collection.
-         */
-        std::string name;
-        /**
-         * @brief Sets of SPaT data ( one per intersection).
-         */
-        std::list<intersection_state> intersections;
-        
-        /**
-         * @brief Map of phase number(NTCIP) to signal group(J2735).
-         */
-        std::unordered_map<int,int> phase_to_signal_group;
+    class spat{
+        private:
+            /**
+             * @brief Timestamp in minutes of the UTC year (see J2735 SPaT message documentation for reference).
+             */
+            u_int32_t timestamp = 0;
+            /**
+             * @brief Descriptive name for this collection.
+             */
+            std::string name;
+            /**
+             * @brief Sets of SPaT data ( one per intersection).
+             */
+            std::list<intersection_state> intersections;
+            
+            /**
+             * @brief Map of phase number(NTCIP) to signal group(J2735).
+             */
+            std::unordered_map<int,int> phase_to_signal_group;
 
-        /**
-         * @brief 
-         */
-        std::shared_mutex spat_lock;
+            /**
+             * @brief Read/Write lock for concurrent access for read operations and exclusive access for write operations.
+             */
+            std::shared_mutex spat_lock;
+        public:
+            /**
+             * @brief Serialize SPaT object to rapidjson::Value for writing as JSON string (Thread Safe).
+             * 
+             * @return rapidjson::Value serialize SPaT object
+             */
+            std::string toJson();
+            /**
+             * @brief Get copy of current intersection state. Note: SPaT object currently only supports storing single intersection
+             * state (Thread Safe).
+             * 
+             * @return intersection_state 
+             */
+            intersection_state get_intersection();
+            /**
+             * @brief Get SPaT name.
+             * 
+             * @return std::string SPaT name.
+             */
+            std::string get_name();
 
-        /**
-         * @brief Serialize SPaT object to rapidjson::Value for writing as JSON string
-         * 
-         * @return rapidjson::Value serialize SPaT object
-         */
-        std::string toJson();
+            /**
+             * @brief Get timestamp in minute of the current UTC year (Thread Safe).
+             * 
+             * @return uint32_t timestamp minute of the current UTC year.
+             */
+            uint32_t get_timestamp();
+            /**
+             * @brief Update current intersection state (Thread Safe).
+             * 
+             * @param intersection intersection state update.
+             */
+            void set_intersection(const intersection_state &intersection);
+            /**
+             * @brief Deserialize SPaT JSON into SPaT object (Thread Safe).
+             * 
+             * @param val SPaT JSON.
+             */
+            void fromJson(const std::string &json);
+            /**
+             * @brief Update spat object data using ntcip_1202_ext data received via UDP socket. 
+             * Bool flag to control whether to use ntcip_1202_ext message provided timestamp or 
+             * host unix timestamp information (Thread Safe).
+             * 
+             * @param ntcip_data bytes from UDP socket, read into a struct
+             * @param use_ntcip_timestamp Bool flag to control whether to use ntcip_1202_ext message provided timestamp or 
+             * host unix timestamp information. If true will use message timestamp. 
+             */
+            void update(ntcip::ntcip_1202_ext &ntcip_data, bool use_ntcip_timestamp );
 
-        intersection_state get_intersection();
-        /**
-         * @brief Deserialize SPaT JSON into SPaT object.
-         * 
-         * @param val SPaT JSON.
-         */
-        void fromJson(const std::string &json);
-        /**
-         * @brief Update spat object data using ntcip_1202_ext data received via UDP socket. 
-         * Bool flag to control whether to use ntcip_1202_ext message provided timestamp or 
-         * host unix timestamp information.
-         * 
-         * @param ntcip_data bytes from UDP socket, read into a struct
-         * @param use_ntcip_timestamp Bool flag to control whether to use ntcip_1202_ext message provided timestamp or 
-         * host unix timestamp information. If true will use message timestamp. 
-         */
-        void update(ntcip::ntcip_1202_ext &ntcip_data, bool use_ntcip_timestamp );
+            /**
+             * @brief Method to initialize intersection information not provided in the ntcip SPaT UDP
+             * message but necessary for the J2735 SPaT message. This method must be executed prior to 
+             * using the update method (Thread Safe).
+             * 
+             * @param intersection_name name of intersection
+             * @param intersection_id J2735 intersection ID
+             * @param phase_number_to_signal_group a map of phase numbers (NTCIP) to signal groups (J2735)
+             */
+            void initialize_intersection(const std::string &intersection_name, const int intersection_id, const std::unordered_map<int,int> &phase_number_to_signal_group);
 
-        /**
-         * @brief Method to initialize intersection information not provided in the ntcip SPaT UDP
-         * message but necessary for the J2735 SPaT message. This method must be executed prior to 
-         * using the update method.
-         * 
-         * @param intersection_name name of intersection
-         * @param intersection_id J2735 intersection ID
-         * @param phase_number_to_signal_group a map of phase numbers (NTCIP) to signal groups (J2735)
-         */
-        void initialize_intersection(const std::string &intersection_name, const int intersection_id, const std::unordered_map<int,int> &phase_number_to_signal_group);
+            /**
+             * @brief Method to set SPaT timestamp based on NTCIP message timestamp. The NTCIP message timestamp consists
+             * of a seconds_of_day and a milliseconds of second field. This method will get the current day from system time
+             * and then apply seconds and milliseconds informat as a offset for the current day.
+             * 
+             * @param second_of_day NTCIP message timestamp information (seconds of the current UTC day).
+             * @param millisecond_of_second NTCIP message timestamp information (millisecond of the current second).
+             */
+            void set_timestamp_ntcip(const uint32_t second_of_day , const uint16_t millisecond_of_second );
 
-        /**
-         * @brief Method to set SPaT timestamp based on NTCIP message timestamp. The NTCIP message timestamp consists
-         * of a seconds_of_day and a milliseconds of second field. This method will get the current day from system time
-         * and then apply seconds and milliseconds informat as a offset for the current day.
-         * 
-         * @param second_of_day NTCIP message timestamp information (seconds of the current UTC day).
-         * @param millisecond_of_second NTCIP message timestamp information (millisecond of the current second).
-         */
-        void set_timestamp_ntcip(const uint32_t second_of_day , const uint16_t millisecond_of_second );
+            /**
+             * @brief Method to set SPaT timestamp based on system time
+             * 
+             */
+            void set_timestamp_local();
 
-        /**
-         * @brief Method to set SPaT timestamp based on system time
-         * 
-         */
-        void set_timestamp_local();
+            /**
+             * @brief Method to update the front entry in the intersections list of
+             * intersection_state(s) with the provided NTCIP SPaT data (Thread Safe).
+             * 
+             * @param ntcip_data 
+             */
+            void update_intersection_state( ntcip::ntcip_1202_ext &ntcip_data );
 
-        /**
-         * @brief Method to update the front entry in the intersections list of
-         * intersection_state(s) with the provided NTCIP SPaT data.
-         * 
-         * @param ntcip_data 
-         */
-        void update_intersection_state( ntcip::ntcip_1202_ext &ntcip_data );
-
-        /**
-         * @brief Equals operator to asses whether two objects contain equivalent data.
-         * 
-         * @param compare second object to compare current object with.
-         * @return true if both object contain equivalent data.
-         * @return false if not.
-         */
-        bool operator==(const spat &other) const;
-        /**
-         * @brief Returns the inverse of equals operator.
-         * 
-         * @param other second object to compare current object with.
-         * @return true if both objects do not contain equivalent data.
-         * @return false if both objects do contain equivalent data.
-         */
-        bool operator!=(const spat &other) const;
+            /**
+             * @brief Equals operator to asses whether two objects contain equivalent data.
+             * 
+             * @param compare second object to compare current object with.
+             * @return true if both object contain equivalent data.
+             * @return false if not.
+             */
+            bool operator==(const spat &other) const;
+            /**
+             * @brief Returns the inverse of equals operator.
+             * 
+             * @param other second object to compare current object with.
+             * @return true if both objects do not contain equivalent data.
+             * @return false if both objects do contain equivalent data.
+             */
+            bool operator!=(const spat &other) const;
     
     };
 

--- a/streets_utils/streets_signal_phase_and_timing/src/models/movement_state.cpp
+++ b/streets_utils/streets_signal_phase_and_timing/src/models/movement_state.cpp
@@ -6,6 +6,9 @@ namespace signal_phase_and_timing {
         rapidjson::Value move_state(rapidjson::kObjectType);
         // Populate
         move_state.AddMember( "movement_name", movement_name, allocator);
+        if ( signal_group == 0 ) {
+            throw signal_phase_and_timing_exception("MovementState is missing required signal_group property!");
+        }
         move_state.AddMember( "signal_group", signal_group, allocator );
         if ( !state_time_speed.empty() ) {
             rapidjson::Value event_list(rapidjson::kArrayType);

--- a/streets_utils/streets_signal_phase_and_timing/src/models/spat.cpp
+++ b/streets_utils/streets_signal_phase_and_timing/src/models/spat.cpp
@@ -139,6 +139,23 @@ namespace signal_phase_and_timing{
 
     }
 
+    std::string spat::get_name() {
+        std::shared_lock lock(spat_lock);
+        return name;
+    }
+
+    uint32_t spat::get_timestamp() {
+        std::shared_lock lock(spat_lock);
+        return timestamp;
+    }
+
+    void spat::set_intersection(const intersection_state &intersection) {
+        // Write lock
+        std::unique_lock lock(spat_lock);
+        intersections.clear();
+        intersections.push_front(intersection);
+    }
+
     bool spat::operator==(const spat &other) const{
         return timestamp == other.timestamp && name == other.name && intersections == other.intersections;
     }

--- a/streets_utils/streets_signal_phase_and_timing/src/models/spat.cpp
+++ b/streets_utils/streets_signal_phase_and_timing/src/models/spat.cpp
@@ -2,11 +2,13 @@
 
 namespace signal_phase_and_timing{
 
-    std::string spat::toJson() const {
+    std::string spat::toJson() {
         rapidjson::Document doc;
         auto allocator = doc.GetAllocator();
         // Create SPaT JSON value
         rapidjson::Value spat(rapidjson::kObjectType);
+        // Read lock
+        std::shared_lock lock(spat_lock);
         // Populate SPat JSON
         spat.AddMember("time_stamp", timestamp, allocator);
         spat.AddMember( "name", name, allocator);
@@ -36,7 +38,8 @@ namespace signal_phase_and_timing{
         if (doc.HasParseError()) {
             throw signal_phase_and_timing_exception("SPaT message JSON is misformatted. JSON parsing failed!");  
         }
-
+        // Write lock
+        std::unique_lock  lock(spat_lock);
         if ( doc.HasMember("time_stamp") && doc.FindMember("time_stamp")->value.IsUint64()) {
             timestamp =  (uint32_t) doc["time_stamp"].GetUint64(); // OPTIONAL in J2735 SPaT definition
         } 
@@ -64,6 +67,8 @@ namespace signal_phase_and_timing{
         if ( phase_to_signal_group.empty() || intersections.front().name.empty() || intersections.front().id == 0) {
             throw signal_phase_and_timing_exception("Before updating SPAT with NTCIP information spat::initialize() must be called! See README documentation!");
         }
+        // Write lock
+        std::unique_lock lock(spat_lock);
         if ( use_ntcip_timestamp ) {
             set_timestamp_ntcip( ntcip_data.get_timestamp_seconds_of_day(), ntcip_data.spat_timestamp_msec);
         } 
@@ -77,6 +82,8 @@ namespace signal_phase_and_timing{
     }
 
     void spat::initialize_intersection(const std::string &intersection_name, const int intersection_id, const std::unordered_map<int,int> &_phase_number_to_signal_group ) {
+        // Write lock
+        std::unique_lock lock(spat_lock);
         if (!intersections.empty()) {
             intersections.clear();
         }
@@ -122,6 +129,14 @@ namespace signal_phase_and_timing{
         else {
             throw signal_phase_and_timing_exception("Intersection State List is empty! Cannot populate status information!");
         }
+    }
+
+    intersection_state spat::get_intersection() {
+        std::shared_lock lock(spat_lock);
+        if (intersections.empty())
+            throw signal_phase_and_timing_exception("No intersection included currently in SPaT!"); 
+        return intersections.front();
+
     }
 
     bool spat::operator==(const spat &other) const{

--- a/streets_utils/streets_signal_phase_and_timing/test/test_intersection_state.cpp
+++ b/streets_utils/streets_signal_phase_and_timing/test/test_intersection_state.cpp
@@ -76,6 +76,7 @@ TEST_F(test_intersection_state, toJson)
     iss.moy= 123;
     iss.status = 32;
     movement_state mms;
+    mms.signal_group=2;
     iss.states.push_back(mms);
     auto json = iss.toJson(allocator);
 

--- a/streets_utils/streets_signal_phase_and_timing/test/test_ntcip_to_spat.cpp
+++ b/streets_utils/streets_signal_phase_and_timing/test/test_ntcip_to_spat.cpp
@@ -77,8 +77,7 @@ class test_ntcip_to_spat : public ::testing::Test {
 
 TEST_F( test_ntcip_to_spat, test_update) {
     // Assert Initiliazition added a single intersection with correct name and id
-    ASSERT_TRUE(!spat_ptr->intersections.empty());
-    intersection_state &intersection =  spat_ptr->intersections.front();
+    intersection_state intersection =  spat_ptr->get_intersection();
     ASSERT_EQ( intersection.name , "Test Intersection" );
     ASSERT_EQ( intersection.id , 12902 );
     ASSERT_EQ( intersection.states.size(), phase_to_signal_group.size());
@@ -87,6 +86,7 @@ TEST_F( test_ntcip_to_spat, test_update) {
     // Line 1 : Green 6 and 2 , Red 8 and 4
     read_next_line();
     spat_ptr->update( spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
     // Calculate current minute of the UTC year
     std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
     time_t tt = std::chrono::system_clock::to_time_t(now);
@@ -94,14 +94,14 @@ TEST_F( test_ntcip_to_spat, test_update) {
     uint32_t moy = utc_tm.tm_yday*60*24 + utc_tm.tm_hour*60 + utc_tm.tm_min;
     ASSERT_EQ( intersection.moy, moy );
     // Get movement state and current event references
-    movement_state &state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
-    movement_state &state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
-    movement_state &state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
-    movement_state &state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
-    movement_event &event_cur_2 = state_2.state_time_speed.front();
-    movement_event &event_cur_4 = state_4.state_time_speed.front();
-    movement_event &event_cur_6 = state_6.state_time_speed.front();
-    movement_event &event_cur_8 = state_8.state_time_speed.front();
+    movement_state state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    movement_state state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
+    movement_state state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
+    movement_state state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
+    movement_event event_cur_2 = state_2.state_time_speed.front();
+    movement_event event_cur_4 = state_4.state_time_speed.front();
+    movement_event event_cur_6 = state_6.state_time_speed.front();
+    movement_event event_cur_8 = state_8.state_time_speed.front();
     // Confirm signal group mapping is correctly set in spat movement states
     ASSERT_EQ( state_2.signal_group, phase_to_signal_group.find(2)->second );
     ASSERT_EQ( state_4.signal_group, phase_to_signal_group.find(4)->second );
@@ -132,6 +132,15 @@ TEST_F( test_ntcip_to_spat, test_update) {
     // Line 2 : Green 8 and 4 , Red 6 and 2
     read_next_line();
     spat_ptr->update( spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
+    state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
+    state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
+    state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
+    event_cur_2 = state_2.state_time_speed.front();
+    event_cur_4 = state_4.state_time_speed.front();
+    event_cur_6 = state_6.state_time_speed.front();
+    event_cur_8 = state_8.state_time_speed.front();
 
     now = std::chrono::system_clock::now();
     tt = std::chrono::system_clock::to_time_t(now);
@@ -164,6 +173,15 @@ TEST_F( test_ntcip_to_spat, test_update) {
     // Line 3 : Green 8 and 4 , Red 6 and 2
     read_next_line();
     spat_ptr->update( spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
+    state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
+    state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
+    state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
+    event_cur_2 = state_2.state_time_speed.front();
+    event_cur_4 = state_4.state_time_speed.front();
+    event_cur_6 = state_6.state_time_speed.front();
+    event_cur_8 = state_8.state_time_speed.front();
     now = std::chrono::system_clock::now();
     tt = std::chrono::system_clock::to_time_t(now);
     utc_tm = *gmtime(&tt);
@@ -194,6 +212,15 @@ TEST_F( test_ntcip_to_spat, test_update) {
     // Line 4 : Green 8 and 4 , Red 6 and 2
     read_next_line();
     spat_ptr->update( spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
+    state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
+    state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
+    state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
+    event_cur_2 = state_2.state_time_speed.front();
+    event_cur_4 = state_4.state_time_speed.front();
+    event_cur_6 = state_6.state_time_speed.front();
+    event_cur_8 = state_8.state_time_speed.front();
     now = std::chrono::system_clock::now();
     tt = std::chrono::system_clock::to_time_t(now);
     utc_tm = *gmtime(&tt);
@@ -224,6 +251,15 @@ TEST_F( test_ntcip_to_spat, test_update) {
     // Line 5 : Yellow 8 and 4 , Red 6 and 2
     read_next_line();
     spat_ptr->update(spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
+    state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
+    state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
+    state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
+    event_cur_2 = state_2.state_time_speed.front();
+    event_cur_4 = state_4.state_time_speed.front();
+    event_cur_6 = state_6.state_time_speed.front();
+    event_cur_8 = state_8.state_time_speed.front();
     ASSERT_EQ( event_cur_2.event_state, movement_phase_state::stop_and_remain);
 
     ASSERT_EQ( event_cur_4.timing.start_time, intersection.convert_offset(0));
@@ -238,6 +274,15 @@ TEST_F( test_ntcip_to_spat, test_update) {
     // Line 6 : Flashing Yellow 8 and 4 , Red 6 and 2
     read_next_line();
     spat_ptr->update(spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
+    state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
+    state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
+    state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
+    event_cur_2 = state_2.state_time_speed.front();
+    event_cur_4 = state_4.state_time_speed.front();
+    event_cur_6 = state_6.state_time_speed.front();
+    event_cur_8 = state_8.state_time_speed.front();
     // Protected clearance for 4 and 8
     ASSERT_EQ( event_cur_2.event_state, movement_phase_state::stop_and_remain);
 
@@ -252,6 +297,15 @@ TEST_F( test_ntcip_to_spat, test_update) {
     // Read line 6 flashing yellow for 4 and 8
     read_next_line();
     spat_ptr->update(spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
+    state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    state_4 =  intersection.get_movement(phase_to_signal_group.find(4)->second);
+    state_6 =  intersection.get_movement(phase_to_signal_group.find(6)->second);
+    state_8 =  intersection.get_movement(phase_to_signal_group.find(8)->second);
+    event_cur_2 = state_2.state_time_speed.front();
+    event_cur_4 = state_4.state_time_speed.front();
+    event_cur_6 = state_6.state_time_speed.front();
+    event_cur_8 = state_8.state_time_speed.front();
     // Protected clearance for 4 and 8
 
     ASSERT_EQ( event_cur_2.timing.start_time, intersection.convert_offset(0));
@@ -271,8 +325,7 @@ TEST_F( test_ntcip_to_spat, test_update) {
 
 TEST_F( test_ntcip_to_spat, test_update_tsc_timestamp) {
     // Assert Initiliazition added a single intersection with correct name and id
-    ASSERT_TRUE(!spat_ptr->intersections.empty());
-    intersection_state &intersection =  spat_ptr->intersections.front();
+    intersection_state intersection =  spat_ptr->get_intersection();
     ASSERT_EQ( intersection.name , "Test Intersection" );
     ASSERT_EQ( intersection.id , 12902 );
     ASSERT_EQ( intersection.states.size(), phase_to_signal_group.size());
@@ -287,12 +340,13 @@ TEST_F( test_ntcip_to_spat, test_update_tsc_timestamp) {
 }
 
 TEST_F( test_ntcip_to_spat, test_update_clear_future_events) {
-    intersection_state &intersection =  spat_ptr->intersections.front();
     // Line 1 : Green 6 and 2 , Red 8 and 4        
     read_next_line();
     spat_ptr->update( spat_ntcip_data, false);
+    intersection_state intersection =  spat_ptr->get_intersection();
+
     // Get movement state and current event references
-    movement_state &state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
+    movement_state state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
     ASSERT_EQ(state_2.state_time_speed.size(), 1);
     // Add future event
     movement_event future_event;
@@ -306,6 +360,8 @@ TEST_F( test_ntcip_to_spat, test_update_clear_future_events) {
     // Line 2 : Green 8 and 4 , Red 6 and 2
     read_next_line();
     spat_ptr->update( spat_ntcip_data, false);
+    intersection =  spat_ptr->get_intersection();
+    state_2 =  intersection.get_movement(phase_to_signal_group.find(2)->second);
     ASSERT_EQ(state_2.state_time_speed.size(), 1);
     ASSERT_EQ(state_2.state_time_speed.front().event_state, movement_phase_state::stop_and_remain);
 }

--- a/streets_utils/streets_tsc_configuration/README.md
+++ b/streets_utils/streets_tsc_configuration/README.md
@@ -21,7 +21,8 @@ This CARMA-Streets library is meant to handle JSON serialization and deserializa
             "signal_group_id": 7,
             "yellow_change_duration":2000,
             "red_clearance":300
-        },
+        }
+    ]
 }
 ```
 The third entry in the list shows a signal group with no concurrent phases. The concurrent_signal groups field is an optional argument. In case of a single ring structure there are not expected to be any concurrent groups and a json message can be constructed without it.

--- a/streets_utils/streets_tsc_configuration/src/tsc_configuration_state.cpp
+++ b/streets_utils/streets_tsc_configuration/src/tsc_configuration_state.cpp
@@ -98,7 +98,7 @@ namespace streets_tsc_configuration
         rapidjson::Document doc;
         doc.Parse(json);
         if (doc.HasParseError()) {
-            throw tsc_configuration_state_exception("tsc configuration state message JSON is misformatted. JSON parsing failed!");  
+            throw tsc_configuration_state_exception("TSC Configuration State JSON is misformatted. JSON parsing failed!");  
         }
         
         if(doc.FindMember("tsc_config_list")->value.IsArray()){
@@ -108,6 +108,9 @@ namespace streets_tsc_configuration
                 config.fromJson(signal_group);
                 tsc_config_list.push_back(config);
             }
+        }
+        else {
+            throw tsc_configuration_state_exception("TSC Configuration State JSON is missing required tsc configuration information!");
         }
         
     }    

--- a/streets_utils/streets_vehicle_scheduler/src/signalized_vehicle_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/src/signalized_vehicle_scheduler.cpp
@@ -157,7 +157,10 @@ namespace streets_vehicle_scheduler {
                     throw scheduling_exception("The connection link lanelet does not have a group_id!");
                 }
                 if (first_link_visited && lane.getSignalGroupId() != signal_group_id){
-                    throw scheduling_exception("The link lanelets connected to the entry lane have different signal_group_ids! The signalized_vehicle_scheduler is only capable of understanding intersection where all connection lanes from a single entry lane share a signal_group_id!");
+                    throw scheduling_exception("The link lanelets connected to the entry lane have "
+                                                "different signal_group_ids! The signalized_vehicle_scheduler"
+                                                " is only capable of understanding intersection where all connection"
+                                                " lanes from a single entry lane share a signal_group_id!");
                 }
                 if (!first_link_visited) {
                     signal_group_id = lane.getSignalGroupId();
@@ -169,7 +172,7 @@ namespace streets_vehicle_scheduler {
         // find the movement_state object
         signal_phase_and_timing::movement_state move_state; 
         if ( spat_ptr ) {
-            for (const auto& ms : spat_ptr->intersections.front().states){
+            for (const auto& ms : spat_ptr->get_intersection().states){
                 if (ms.signal_group == signal_group_id) {
                     move_state = ms;
                     return move_state;

--- a/streets_utils/streets_vehicle_scheduler/test/test_signalized_scenario.cpp
+++ b/streets_utils/streets_vehicle_scheduler/test/test_signalized_scenario.cpp
@@ -64,8 +64,8 @@ namespace {
             signal_phase_and_timing::spat spat_message;
             std::string json_spat = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[155,156,160,161,165,169],\"states\":[{\"movement_name\":\"All Directions\",\"signal_group\":1,\"state_time_speed\":[{\"event_state\":6,\"timing\":{\"start_time\":9950,\"min_end_time\":10100}},{\"event_state\":8,\"timing\":{\"start_time\":10100,\"min_end_time\":10130}}, {\"event_state\":3,\"timing\":{\"start_time\":10130,\"min_end_time\":10300}}]},{\"movement_name\":\"All Directions\",\"signal_group\":2,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":9950,\"min_end_time\":10150}},{\"event_state\":6,\"timing\":{\"start_time\":10150,\"min_end_time\":10250}}, {\"event_state\":8,\"timing\":{\"start_time\":10250,\"min_end_time\":10280}}, {\"event_state\":3,\"timing\":{\"start_time\":10280,\"min_end_time\":10300}}]},{\"movement_name\":\"All Directions\",\"signal_group\":3,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":9950,\"min_end_time\":10300}}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
             
-            spat_message.fromJson(json_spat);
-            spat_ptr = std::make_shared<signal_phase_and_timing::spat>(spat_message);
+            spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
+            spat_ptr->fromJson(json_spat);
             scheduler->set_spat(spat_ptr);
             scheduler->set_initial_green_buffer(2000);
             scheduler->set_final_green_buffer(2000);

--- a/streets_utils/streets_vehicle_scheduler/test/test_signalized_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/test/test_signalized_scheduler.cpp
@@ -61,10 +61,10 @@ namespace {
              * Signal group 3 is red from 9950 to 10300. 
              */
 
-            signal_phase_and_timing::spat spat_message;
             std::string json_spat = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[155,156,160,161,165,169],\"states\":[{\"movement_name\":\"All Directions\",\"signal_group\":1,\"state_time_speed\":[{\"event_state\":6,\"timing\":{\"start_time\":9950,\"min_end_time\":10100}},{\"event_state\":8,\"timing\":{\"start_time\":10100,\"min_end_time\":10130}}, {\"event_state\":3,\"timing\":{\"start_time\":10130,\"min_end_time\":10300}}]},{\"movement_name\":\"All Directions\",\"signal_group\":2,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":9950,\"min_end_time\":10150}},{\"event_state\":6,\"timing\":{\"start_time\":10150,\"min_end_time\":10250}}, {\"event_state\":8,\"timing\":{\"start_time\":10250,\"min_end_time\":10280}}, {\"event_state\":3,\"timing\":{\"start_time\":10280,\"min_end_time\":10300}}]},{\"movement_name\":\"All Directions\",\"signal_group\":3,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":9950,\"min_end_time\":10300}}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
-            spat_message.fromJson(json_spat);
-            spat_ptr = std::make_shared<signal_phase_and_timing::spat>(spat_message);
+            spat_ptr = std::make_shared<signal_phase_and_timing::spat>();
+            spat_ptr->fromJson(json_spat);
+
             scheduler->set_spat(spat_ptr);
             scheduler->set_initial_green_buffer(2000);
             scheduler->set_final_green_buffer(2000);

--- a/streets_utils/streets_vehicle_scheduler/test/test_signalized_scheduler.cpp
+++ b/streets_utils/streets_vehicle_scheduler/test/test_signalized_scheduler.cpp
@@ -163,7 +163,9 @@ TEST_F(signalized_scheduler_test, one_ev_one_decelration){
     ASSERT_EQ( sched->vehicle_schedules.front().v_id, veh._id);
 
     SPDLOG_INFO("schedule timestamp = {0}, eet = {1}, et = {2} ", sched->timestamp, sched->vehicle_schedules.front().eet, sched->vehicle_schedules.front().et);
-    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_start_time(), spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
+    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", 
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_start_time(),
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
 
     double eet_time =(sched->vehicle_schedules.front().eet-sched->timestamp)/1000.0;
     SPDLOG_INFO( "EET time for scheduler  : {0}  vs calculated {1} ", eet_time, 1.009 );
@@ -213,7 +215,9 @@ TEST_F(signalized_scheduler_test, one_ev_without_cruising){
     ASSERT_EQ( sched->vehicle_schedules.front().v_id, veh._id);
 
     SPDLOG_INFO("schedule timestamp = {0}, eet = {1}, et = {2} ", sched->timestamp, sched->vehicle_schedules.front().eet, sched->vehicle_schedules.front().et);
-    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_start_time(), spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
+    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", 
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_start_time(), 
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
 
     double eet_time =(sched->vehicle_schedules.front().eet-sched->timestamp)/1000.0;
     SPDLOG_INFO( "EET time for scheduler  : {0}  vs calculated {1} ", eet_time, 5.291 );
@@ -264,7 +268,9 @@ TEST_F(signalized_scheduler_test, one_ev_with_cruising_1){
     ASSERT_EQ( sched->vehicle_schedules.front().v_id, veh._id);
 
     SPDLOG_INFO("schedule timestamp = {0}, eet = {1}, et = {2} ", sched->timestamp, sched->vehicle_schedules.front().eet, sched->vehicle_schedules.front().et);
-    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_start_time(), spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
+    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", 
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_start_time(),
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
 
     double eet_time =(sched->vehicle_schedules.front().eet-sched->timestamp)/1000.0;
     SPDLOG_INFO( "EET time for scheduler  : {0}  vs calculated {1} ", eet_time, 10.736 );
@@ -317,7 +323,9 @@ TEST_F(signalized_scheduler_test, one_ev_with_cruising_2){
     ASSERT_EQ( sched->vehicle_schedules.front().v_id, veh._id);
 
     SPDLOG_INFO("schedule timestamp = {0}, eet = {1}, et = {2} ", sched->timestamp, sched->vehicle_schedules.front().eet, sched->vehicle_schedules.front().et);
-    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_start_time(), spat_ptr->intersections.front().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
+    SPDLOG_INFO(" spat first phase start time = {0}, spat first phase end time = {1} ", 
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_start_time(), 
+        spat_ptr->get_intersection().states.front().state_time_speed.front().timing.get_epoch_min_end_time());
 
     double eet_time =(sched->vehicle_schedules.front().eet-sched->timestamp)/1000.0;
     SPDLOG_INFO( "EET time for scheduler  : {0}  vs calculated {1} ", eet_time, 8.678 );

--- a/tsc_client_service/include/tsc_service.h
+++ b/tsc_client_service/include/tsc_service.h
@@ -46,6 +46,9 @@ namespace traffic_signal_controller_service {
              * and red clearance, yellow change, min/max green times.
              */
             std::shared_ptr<tsc_state> tsc_state_ptr;
+            /**
+             * @brief Object used to process and store desired phase plan consumed from kafka,
+             */
             std::shared_ptr<monitor_desired_phase_plan> monitor_dpp_ptr;
             /**
              * @brief snmp_client used for making SNMP GET and SET calls th NTCIP OIDs to set
@@ -71,8 +74,8 @@ namespace traffic_signal_controller_service {
              */
             std::shared_ptr<intersection_client> intersection_client_ptr;
 
-            // Counter for publishing the tsc_config information. The configuration will be published a hardcoded 10 times
-            int tsc_config_producer_counter_ = 0;
+            // Default value for number of attempts to send TSC configuration information.
+            int tsc_config_send_attempts = 1;
 
             // desired phase plan information consumed from desire_phase_plan Kafka topic
             bool use_desired_phase_plan_update_ = false;

--- a/tsc_client_service/manifest.json
+++ b/tsc_client_service/manifest.json
@@ -95,6 +95,12 @@
             "value": "tsc_config_state",
             "description": "Kafka topic for streets internal Traffic Signal Controller config message",
             "type": "STRING"
+        },
+        {
+            "name": "tsc_config_send_attempts",
+            "value": 5,
+            "description": "Number of times TSC Service will send TSC Configuration Information on startup.",
+            "type":"INTEGER"
         }
         
     ]

--- a/tsc_client_service/src/monitor_desired_phase_plan.cpp
+++ b/tsc_client_service/src/monitor_desired_phase_plan.cpp
@@ -23,7 +23,8 @@ namespace traffic_signal_controller_service
         {
             throw monitor_desired_phase_plan_exception("Intersections cannot be empty!");
         }
-        auto states = spat_ptr->intersections.front().states;
+        auto intersection = spat_ptr->get_intersection();
+        auto states = intersection.states;
 
         if (states.empty())
         {
@@ -56,7 +57,7 @@ namespace traffic_signal_controller_service
                 }
 
                 // Get movement_state by reference. With this reference, it can update the original SPAT movement state list
-                auto &cur_movement_state_ref = spat_ptr->intersections.front().get_movement(current_signal_group_id);
+                auto &cur_movement_state_ref = intersection.get_movement(current_signal_group_id);
 
                 // Processing the next current or first desired future movement event from the desired phase plan
                 if (is_procssing_first_desired_green)
@@ -71,6 +72,8 @@ namespace traffic_signal_controller_service
             }
             is_procssing_first_desired_green = false;
         }
+        // Update spat pointer with new intersection state.
+        spat_ptr->set_intersection(intersection);
     }
 
     void monitor_desired_phase_plan::process_first_desired_green(signal_phase_and_timing::movement_state &cur_movement_state_ref, const streets_desired_phase_plan::signal_group2green_phase_timing &desired_sg_green_timing, const std::shared_ptr<tsc_state> tsc_state_ptr) const

--- a/tsc_client_service/src/monitor_desired_phase_plan.cpp
+++ b/tsc_client_service/src/monitor_desired_phase_plan.cpp
@@ -19,10 +19,6 @@ namespace traffic_signal_controller_service
         {
             throw monitor_desired_phase_plan_exception("SPAT and TSC state pointers cannot be null. SKIP prcessing!");
         }
-        if (spat_ptr->intersections.empty())
-        {
-            throw monitor_desired_phase_plan_exception("Intersections cannot be empty!");
-        }
         auto intersection = spat_ptr->get_intersection();
         auto states = intersection.states;
 

--- a/tsc_client_service/src/monitor_tsc_state.cpp
+++ b/tsc_client_service/src/monitor_tsc_state.cpp
@@ -143,7 +143,8 @@ namespace traffic_signal_controller_service
     {
         // Modify spat according to phase configuration
         // Note: Only first intersection is populated
-        for (auto movement : spat_ptr->intersections.front().states)
+        auto intersection_state = spat_ptr->get_intersection();
+        for (auto movement : intersection_state.states)
         {
             int signal_group_id = movement.signal_group;
 
@@ -156,7 +157,7 @@ namespace traffic_signal_controller_service
             }
 
             // Get movement_state by reference
-            auto& current_movement = spat_ptr->intersections.front().get_movement(signal_group_id);
+            auto& current_movement = intersection_state.get_movement(signal_group_id);
 
             // Get start time as epoch time
             uint64_t start_time = movement.state_time_speed.front().timing.get_epoch_start_time();
@@ -203,6 +204,7 @@ namespace traffic_signal_controller_service
             }
             
         }
+        spat_ptr->set_intersection(intersection_state);
         
     }
 

--- a/tsc_client_service/src/tsc_service.cpp
+++ b/tsc_client_service/src/tsc_service.cpp
@@ -206,13 +206,21 @@ namespace traffic_signal_controller_service {
     }
 
     void tsc_service::produce_tsc_config_json() {
-        // Publish tsc_config information 10 times
+        // Get configuration parameter value
         try {
-            while(tsc_config_state_ptr && tsc_config_producer_counter_ < 10)
+            tsc_config_send_attempts = streets_service::streets_configuration::get_int_config("tsc_config_send_attempts");
+        }
+        catch (const streets_service::streets_configuration_exception &e) {
+            SPDLOG_ERROR("Excecption encountered attempting to publish TSC Configuration : \n {0}", e.what());
+        }
+
+        try {
+            int producer_counter_ = 0;
+            while(tsc_config_state_ptr && producer_counter_ < tsc_config_send_attempts)
             { 
                 
                 tsc_config_producer->send(tsc_config_state_ptr->toJson());
-                tsc_config_producer_counter_ ++;
+                producer_counter_ ++;
 
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // Sleep for 1 second between publish   
             }

--- a/tsc_client_service/test/test_monitor_desired_phase_plan.cpp
+++ b/tsc_client_service/test/test_monitor_desired_phase_plan.cpp
@@ -133,9 +133,9 @@ namespace traffic_signal_controller_service
             intersection_state_two.states.push_back(state_8);
             intersection_state_three.states.push_back(state_8);
 
-            spat_msg_ptr->intersections.push_back(intersection_state);
-            spat_msg_two_ptr->intersections.push_back(intersection_state_two);
-            spat_msg_three_ptr->intersections.push_back(intersection_state_three);
+            spat_msg_ptr->set_intersection(intersection_state);
+            spat_msg_two_ptr->set_intersection(intersection_state_two);
+            spat_msg_three_ptr->set_intersection(intersection_state_three);
 
             // mock tsc_state
             std::string dummy_ip = "192.168.10.10";
@@ -183,25 +183,24 @@ namespace traffic_signal_controller_service
         try {
             monitor_dpp_ptr->update_spat_future_movement_events(invalid_spat_msg_ptr, tsc_state_ptr);
         }
-        catch( const monitor_desired_phase_plan_exception &e ) {
-            ASSERT_STREQ(e.what(), "Intersections cannot be empty!");
+        catch( const signal_phase_and_timing::signal_phase_and_timing_exception &e ) {
+            ASSERT_STREQ(e.what(), "No intersection included currently in SPaT!");
         }
-        ASSERT_TRUE(invalid_spat_msg_ptr->intersections.empty());
+        ASSERT_THROW(invalid_spat_msg_ptr->get_intersection(), signal_phase_and_timing::signal_phase_and_timing_exception);
         signal_phase_and_timing::intersection_state intersection;
-        invalid_spat_msg_ptr->intersections.push_back(intersection);
+        invalid_spat_msg_ptr->set_intersection(intersection);
         try {
             monitor_dpp_ptr->update_spat_future_movement_events(invalid_spat_msg_ptr, tsc_state_ptr);
         }
         catch( const monitor_desired_phase_plan_exception &e) {
             ASSERT_STREQ(e.what(), "Intersections states cannot be empty!");
         }
-        ASSERT_FALSE(invalid_spat_msg_ptr->intersections.empty());
-        ASSERT_TRUE(invalid_spat_msg_ptr->intersections.front().states.empty());
+        ASSERT_TRUE(invalid_spat_msg_ptr->get_intersection().states.empty());
 
         // Current spat should only contain the ONLY one current movement event for each movement state.
-        for (auto movement_state : spat_msg_ptr->intersections.front().states)
+        for (auto movement_state : spat_msg_ptr->get_intersection().states)
         {
-            ASSERT_EQ(8, spat_msg_ptr->intersections.front().states.size());
+            ASSERT_EQ(8, spat_msg_ptr->get_intersection().states.size());
             ASSERT_EQ(1, movement_state.state_time_speed.size());
         }
 
@@ -217,9 +216,9 @@ namespace traffic_signal_controller_service
         catch( const monitor_desired_phase_plan_exception &e) {
             ASSERT_STREQ(e.what(), "Desired phase plan is empty. No update.");
         }
-        for (auto movement_state : spat_msg_ptr->intersections.front().states)
+        for (auto movement_state : spat_msg_ptr->get_intersection().states)
         {
-            ASSERT_EQ(8, spat_msg_ptr->intersections.front().states.size());
+            ASSERT_EQ(8, spat_msg_ptr->get_intersection().states.size());
             ASSERT_EQ(1, movement_state.state_time_speed.size());
         }
 
@@ -232,9 +231,9 @@ namespace traffic_signal_controller_service
         catch (const monitor_desired_phase_plan_exception &e) {
             ASSERT_STREQ(e.what(), "Desired phase plan signal group ids list is empty. No update.");
         }
-        for (auto movement_state : spat_msg_ptr->intersections.front().states)
+        for (auto movement_state : spat_msg_ptr->get_intersection().states)
         {
-            ASSERT_EQ(8, spat_msg_ptr->intersections.front().states.size());
+            ASSERT_EQ(8, spat_msg_ptr->get_intersection().states.size());
             ASSERT_EQ(1, movement_state.state_time_speed.size());
         }
 
@@ -247,7 +246,7 @@ namespace traffic_signal_controller_service
          * ***/
         // Add future movement events
         monitor_dpp_ptr->update_spat_future_movement_events(spat_msg_ptr, tsc_state_ptr);
-        for (auto movement_state : spat_msg_ptr->intersections.front().states)
+        for (auto movement_state : spat_msg_ptr->get_intersection().states)
         {
             int sg = (int)movement_state.signal_group;
             SPDLOG_DEBUG("\n");
@@ -423,7 +422,7 @@ namespace traffic_signal_controller_service
          * ***/
         // Add future movement events
         monitor_dpp_ptr->update_spat_future_movement_events(spat_msg_two_ptr, tsc_state_ptr);
-        for (auto movement_state : spat_msg_two_ptr->intersections.front().states)
+        for (auto movement_state : spat_msg_two_ptr->get_intersection().states)
         {
             int sg = (int)movement_state.signal_group;
             SPDLOG_DEBUG("\n");
@@ -606,7 +605,7 @@ namespace traffic_signal_controller_service
          * ***/
         // Add future movement events
         monitor_dpp_ptr->update_spat_future_movement_events(spat_msg_three_ptr, tsc_state_ptr);
-        for (auto movement_state : spat_msg_three_ptr->intersections.front().states)
+        for (auto movement_state : spat_msg_three_ptr->get_intersection().states)
         {
             int sg = (int)movement_state.signal_group;
             SPDLOG_DEBUG("\n");

--- a/tsc_client_service/test/test_monitor_state.cpp
+++ b/tsc_client_service/test/test_monitor_state.cpp
@@ -222,6 +222,8 @@ namespace traffic_signal_controller_service
             
             else if(it.event_state == signal_phase_and_timing::movement_phase_state::stop_and_remain)
                 EXPECT_EQ(it.timing.min_end_time - it.timing.start_time, phase_1_state.red_duration/100);
+            else 
+                GTEST_FAIL();
         }       
 
         // Test exception 

--- a/tsc_client_service/test/test_monitor_state.cpp
+++ b/tsc_client_service/test/test_monitor_state.cpp
@@ -174,6 +174,8 @@ namespace traffic_signal_controller_service
         state_3.state_time_speed.push_back(event_3);
 
         intersection_state.states.push_back(state_3);
+        spat_msg_ptr->set_intersection(intersection_state);
+        SPDLOG_INFO("Setting Intersection state!");
 
         streets_service::streets_configuration::initialize_logger();
         std::string dummy_ip = "192.168.10.10";
@@ -207,12 +209,13 @@ namespace traffic_signal_controller_service
         phase_3_state.signal_group_id = 3;
         phase_3_state.phase_num = 3;
 
-        spat_msg_ptr->intersections.push_back(intersection_state);
         worker.add_future_movement_events(spat_msg_ptr);
+        SPDLOG_INFO( "Updating future movement events in SPAT");
+        auto new_intersection_state = spat_msg_ptr->get_intersection();
         
         // Check if movement events have been added
-        EXPECT_TRUE(spat_msg_ptr->intersections.front().states.front().state_time_speed.size() > 1);
-        for(auto it : spat_msg_ptr->intersections.front().states.front().state_time_speed){
+        EXPECT_TRUE(new_intersection_state.states.front().state_time_speed.size() > 1);
+        for(auto it : new_intersection_state.states.front().state_time_speed){
             
             if(it.event_state == signal_phase_and_timing::movement_phase_state::protected_movement_allowed)
                 EXPECT_EQ(it.timing.min_end_time - it.timing.start_time , phase_1_state.green_duration/100);
@@ -235,7 +238,7 @@ namespace traffic_signal_controller_service
         intersection_state_2.states.push_back(state_4);
         
         auto spat_msg_ptr_2 = std::make_shared<signal_phase_and_timing::spat>();
-        spat_msg_ptr->intersections.push_back(intersection_state_2);
+        spat_msg_ptr->set_intersection(intersection_state_2);
         EXPECT_THROW(worker.add_future_movement_events(spat_msg_ptr),monitor_states_exception);
 
     }

--- a/tsc_client_service/test/test_tsc_service.cpp
+++ b/tsc_client_service/test/test_tsc_service.cpp
@@ -74,7 +74,6 @@ TEST(traffic_signal_controller_service, test_produce_tsc_config_json_timeout) {
 
     service.tsc_config_state_ptr = std::make_shared<streets_tsc_configuration::tsc_configuration_state>(state);
     service.produce_tsc_config_json();
-    EXPECT_EQ(service.tsc_config_producer_counter_, 10);
 }
 
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Update **Signal Optimization Service** to consume Traffic Signal Controller (TSC) configuration information from **TSC Service**.
## Related Issue
#219 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
**Signal Optimization Service** needs information about TSC configuration such as red clearance interval, yellow change and concurrent signal groups to create valid movement groups and valid desired phase plan durations.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
