### PR TITLE
Modernize and clean up `CMakeLists.txt` for `streets_service_base`

### DIFF
--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -1,11 +1,12 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16)
 project(streets_service_base)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
+include(dependencies.cmake)
+
 find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
-find_package(spdlog 1.10.0 EXACT REQUIRED)
-find_package(RapidJSON 1.1.0 REQUIRED)
+find_package(GTest REQUIRED MODULE)
 add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
 
@@ -85,6 +86,6 @@ target_link_libraries(${BINARY} PUBLIC
                 Boost::thread
                 Boost::filesystem
                 spdlog::spdlog
-                gtest
+                GTest::GTest
                 ${PROJECT_NAME}_lib
                 )

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -1,107 +1,21 @@
 cmake_minimum_required(VERSION 3.16)
 project(streets_service_base)
+enable_testing()
 
-include(GNUInstallDirs)
+# In CMake 3.21, PROJECT_IS_TOP_LEVEL is provided, so if block can be removed when the
+# project upgrades to that CMake version
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(PROJECT_IS_TOP_LEVEL TRUE CACHE INTERNAL "")
+else()
+  set(PROJECT_IS_TOP_LEVEL FALSE CACHE INTERNAL "")
+endif()
+
+option(STREETSSERVICEBASE_ENABLE_TESTING "Enable unit tests for streets_service_base" ${PROJECT_IS_TOP_LEVEL})
 
 include(dependencies.cmake)
 
-add_library(streets_service_base_lib
-  src/streets_configuration_exception.cpp
-  src/configuration.cpp
-  src/streets_configuration.cpp
-)
+add_subdirectory(src)
 
-target_compile_definitions(streets_service_base_lib
-  PRIVATE
-    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE
-)
-
-target_compile_options(streets_service_base_lib
-  PRIVATE
-    -fPIC
-)
-
-target_include_directories(streets_service_base_lib
-  PUBLIC
-    $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-)
-
-target_link_libraries(streets_service_base_lib
-  PUBLIC
-    Boost::system
-    Boost::thread
-    Boost::filesystem
-    spdlog::spdlog
-)
-
-########################################################
-# Install streets_service_base_lib package.
-########################################################
-install(TARGETS streets_service_base_lib
-  EXPORT streets_service_base_libTargets
-  INCLUDES
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  LIBRARY
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
-install(EXPORT streets_service_base_libTargets
-  FILE streets_service_base_libTargets.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/streets_service_base_lib
-  NAMESPACE streets_service_base_lib::
-)
-
-include(CMakePackageConfigHelpers)
-configure_package_config_file(
-  cmake/streets_service_base_libConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
-  INSTALL_DESTINATION  lib/streets_service_base_lib/streets_service_base_lib/
-)
-
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
-  DESTINATION lib/cmake/streets_service_base_lib/
-)
-
-install(DIRECTORY include
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING
-    PATTERN *.h
-    PATTERN *.tpp
-)
-
-########################
-# googletest for unit testing
-########################
-add_executable(streets_service_base_test
-  test/test_main.cpp
-  test/test_streets_configuration.cpp
-  test/test_streets_singleton.cpp
-)
-
-target_compile_definitions(streets_service_base_test
-  PRIVATE
-    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_ERROR
-)
-
-target_include_directories(streets_service_base_test
-  PRIVATE
-    ${PROJECT_SOURCE_DIR}/include
-)
-
-target_link_libraries(streets_service_base_test
-  PRIVATE
-    Boost::system
-    Boost::thread
-    Boost::filesystem
-    spdlog::spdlog
-    GTest::GTest
-    streets_service_base_lib
-)
-
-gtest_discover_tests(streets_service_base_test)
+if(STREETSSERVICEBASE_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
+  add_subdirectory(test)
+endif()

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(streets_service_base)
-                    
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
-find_package(Boost COMPONENTS system filesystem thread REQUIRED)
-find_package(spdlog REQUIRED)
+find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
+find_package(spdlog 1.10.0 EXACT REQUIRED)
+find_package(RapidJSON 1.1.0 REQUIRED)
 add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
 
@@ -22,13 +23,13 @@ target_include_directories(${PROJECT_NAME}_lib PUBLIC
                             PRIVATE
                             ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries( ${PROJECT_NAME}_lib PUBLIC
-                Boost::system 
-                Boost::thread 
+                Boost::system
+                Boost::thread
                 Boost::filesystem
                 spdlog::spdlog
                 )
 
-                
+
 
 ########################################################
 # Install streets_service_base_lib package.
@@ -44,14 +45,14 @@ install(
     ARCHIVE DESTINATION lib
 )
 install(
-    EXPORT ${PROJECT_NAME}_libTargets 
+    EXPORT ${PROJECT_NAME}_libTargets
     FILE ${PROJECT_NAME}_libTargets.cmake
     DESTINATION lib/cmake/${PROJECT_NAME}_lib/
     NAMESPACE ${PROJECT_NAME}_lib::
 )
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-    cmake/${PROJECT_NAME}_libConfig.cmake.in 
+    cmake/${PROJECT_NAME}_libConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_libConfig.cmake
     INSTALL_DESTINATION  lib/${PROJECT_NAME}_lib/${PROJECT_NAME}_lib/ )
 install(
@@ -71,7 +72,7 @@ file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.h test/*.cpp)
 set(SOURCES ${TEST_SOURCES} WORKING_DIRECTORY  ${PROJECT_SOURCE_DIR}/test)
 
 
-add_executable(${BINARY} ${TEST_SOURCES} 
+add_executable(${BINARY} ${TEST_SOURCES}
                 src/streets_configuration_exception.cpp
                 src/configuration.cpp
                 src/streets_configuration.cpp
@@ -79,11 +80,11 @@ add_executable(${BINARY} ${TEST_SOURCES}
 
 add_test(NAME ${BINARY} COMMAND ${BINARY})
 target_include_directories(${BINARY} PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(${BINARY} PUBLIC 
-                Boost::system 
+target_link_libraries(${BINARY} PUBLIC
+                Boost::system
                 Boost::thread
-                Boost::filesystem 
+                Boost::filesystem
                 spdlog::spdlog
-                gtest 
+                gtest
                 ${PROJECT_NAME}_lib
                 )

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.10.2)
 project(streets_service_base)
 enable_testing()
 

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -11,19 +11,19 @@ add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
 
 
-add_library(${PROJECT_NAME}_lib
+add_library(streets_service_base_lib
                 src/streets_configuration_exception.cpp
                 src/configuration.cpp
                 src/streets_configuration.cpp
                 )
 
 
-target_include_directories(${PROJECT_NAME}_lib PUBLIC
+target_include_directories(streets_service_base_lib PUBLIC
                             $<INSTALL_INTERFACE:include>
                             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                             PRIVATE
                             ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries( ${PROJECT_NAME}_lib PUBLIC
+target_link_libraries( streets_service_base_lib PUBLIC
                 Boost::system
                 Boost::thread
                 Boost::filesystem
@@ -39,26 +39,26 @@ file(GLOB files ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
 file(GLOB templates ${CMAKE_CURRENT_SOURCE_DIR}/include/internal/*.tpp)
 
 install(
-    TARGETS ${PROJECT_NAME}_lib
-    EXPORT ${PROJECT_NAME}_libTargets
+    TARGETS streets_service_base_lib
+    EXPORT streets_service_base_libTargets
     LIBRARY DESTINATION lib
     INCLUDES DESTINATION include
     ARCHIVE DESTINATION lib
 )
 install(
-    EXPORT ${PROJECT_NAME}_libTargets
-    FILE ${PROJECT_NAME}_libTargets.cmake
-    DESTINATION lib/cmake/${PROJECT_NAME}_lib/
-    NAMESPACE ${PROJECT_NAME}_lib::
+    EXPORT streets_service_base_libTargets
+    FILE streets_service_base_libTargets.cmake
+    DESTINATION lib/cmake/streets_service_base_lib/
+    NAMESPACE streets_service_base_lib::
 )
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-    cmake/${PROJECT_NAME}_libConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_libConfig.cmake
-    INSTALL_DESTINATION  lib/${PROJECT_NAME}_lib/${PROJECT_NAME}_lib/ )
+    cmake/streets_service_base_libConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
+    INSTALL_DESTINATION  lib/streets_service_base_lib/streets_service_base_lib/ )
 install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_libConfig.cmake
-    DESTINATION  lib/cmake/${PROJECT_NAME}_lib/
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
+    DESTINATION  lib/cmake/streets_service_base_lib/
 )
 install(FILES ${files} DESTINATION include)
 install(FILES ${templates} DESTINATION include/internal)
@@ -68,7 +68,7 @@ install(FILES ${templates} DESTINATION include/internal)
 # googletest for unit testing
 ########################
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-set(BINARY ${PROJECT_NAME}_test)
+set(BINARY streets_service_base_test)
 file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.h test/*.cpp)
 set(SOURCES ${TEST_SOURCES} WORKING_DIRECTORY  ${PROJECT_SOURCE_DIR}/test)
 
@@ -87,5 +87,5 @@ target_link_libraries(${BINARY} PUBLIC
                 Boost::filesystem
                 spdlog::spdlog
                 GTest::GTest
-                ${PROJECT_NAME}_lib
+                streets_service_base_lib
                 )

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -5,8 +5,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 include(dependencies.cmake)
 
-find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
-find_package(GTest REQUIRED MODULE)
 add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
 add_library(streets_service_base_lib
@@ -37,7 +35,7 @@ target_link_libraries(streets_service_base_lib
 file(GLOB files ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
 file(GLOB templates ${CMAKE_CURRENT_SOURCE_DIR}/include/internal/*.tpp)
 
-install(TARGETS streets_service_base_lib spdlog
+install(TARGETS streets_service_base_lib
   EXPORT streets_service_base_libTargets
   LIBRARY DESTINATION lib
   INCLUDES DESTINATION include

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -9,28 +9,27 @@ find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
 find_package(GTest REQUIRED MODULE)
 add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
-
-
 add_library(streets_service_base_lib
-                src/streets_configuration_exception.cpp
-                src/configuration.cpp
-                src/streets_configuration.cpp
-                )
+  src/streets_configuration_exception.cpp
+  src/configuration.cpp
+  src/streets_configuration.cpp
+)
 
+target_include_directories(streets_service_base_lib
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
 
-target_include_directories(streets_service_base_lib PUBLIC
-                            $<INSTALL_INTERFACE:include>
-                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                            PRIVATE
-                            ${CMAKE_CURRENT_SOURCE_DIR}/src)
-target_link_libraries( streets_service_base_lib PUBLIC
-                Boost::system
-                Boost::thread
-                Boost::filesystem
-                spdlog::spdlog
-                )
-
-
+target_link_libraries(streets_service_base_lib
+  PUBLIC
+    Boost::system
+    Boost::thread
+    Boost::filesystem
+    spdlog::spdlog
+)
 
 ########################################################
 # Install streets_service_base_lib package.
@@ -38,31 +37,33 @@ target_link_libraries( streets_service_base_lib PUBLIC
 file(GLOB files ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
 file(GLOB templates ${CMAKE_CURRENT_SOURCE_DIR}/include/internal/*.tpp)
 
-install(
-    TARGETS streets_service_base_lib spdlog
-    EXPORT streets_service_base_libTargets
-    LIBRARY DESTINATION lib
-    INCLUDES DESTINATION include
-    ARCHIVE DESTINATION lib
+install(TARGETS streets_service_base_lib spdlog
+  EXPORT streets_service_base_libTargets
+  LIBRARY DESTINATION lib
+  INCLUDES DESTINATION include
+  ARCHIVE DESTINATION lib
 )
-install(
-    EXPORT streets_service_base_libTargets
-    FILE streets_service_base_libTargets.cmake
-    DESTINATION lib/cmake/streets_service_base_lib/
-    NAMESPACE streets_service_base_lib::
+
+install(EXPORT streets_service_base_libTargets
+  FILE streets_service_base_libTargets.cmake
+  DESTINATION lib/cmake/streets_service_base_lib/
+  NAMESPACE streets_service_base_lib::
 )
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-    cmake/streets_service_base_libConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
-    INSTALL_DESTINATION  lib/streets_service_base_lib/streets_service_base_lib/ )
-install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
-    DESTINATION  lib/cmake/streets_service_base_lib/
+  cmake/streets_service_base_libConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
+  INSTALL_DESTINATION  lib/streets_service_base_lib/streets_service_base_lib/
 )
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/streets_service_base_libConfig.cmake
+  DESTINATION lib/cmake/streets_service_base_lib/
+)
+
 install(FILES ${files} DESTINATION include)
 install(FILES ${templates} DESTINATION include/internal)
-
 
 ########################
 # googletest for unit testing
@@ -72,20 +73,20 @@ set(BINARY streets_service_base_test)
 file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.h test/*.cpp)
 set(SOURCES ${TEST_SOURCES} WORKING_DIRECTORY  ${PROJECT_SOURCE_DIR}/test)
 
-
 add_executable(${BINARY} ${TEST_SOURCES}
-                src/streets_configuration_exception.cpp
-                src/configuration.cpp
-                src/streets_configuration.cpp
-                )
+  src/streets_configuration_exception.cpp
+  src/configuration.cpp
+  src/streets_configuration.cpp
+)
 
 add_test(NAME ${BINARY} COMMAND ${BINARY})
 target_include_directories(${BINARY} PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(${BINARY} PUBLIC
-                Boost::system
-                Boost::thread
-                Boost::filesystem
-                spdlog::spdlog
-                GTest::GTest
-                streets_service_base_lib
-                )
+target_link_libraries(${BINARY}
+  PUBLIC
+    Boost::system
+    Boost::thread
+    Boost::filesystem
+    spdlog::spdlog
+    GTest::GTest
+    streets_service_base_lib
+)

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(streets_service_base)
 
+include(GNUInstallDirs)
+
 include(dependencies.cmake)
 
 add_library(streets_service_base_lib
@@ -43,14 +45,17 @@ file(GLOB templates ${CMAKE_CURRENT_SOURCE_DIR}/include/internal/*.tpp)
 
 install(TARGETS streets_service_base_lib
   EXPORT streets_service_base_libTargets
-  LIBRARY DESTINATION lib
-  INCLUDES DESTINATION include
-  ARCHIVE DESTINATION lib
+  INCLUDES
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  LIBRARY
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 install(EXPORT streets_service_base_libTargets
   FILE streets_service_base_libTargets.cmake
-  DESTINATION lib/cmake/streets_service_base_lib/
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/streets_service_base_lib
   NAMESPACE streets_service_base_lib::
 )
 
@@ -66,8 +71,12 @@ install(
   DESTINATION lib/cmake/streets_service_base_lib/
 )
 
-install(FILES ${files} DESTINATION include)
-install(FILES ${templates} DESTINATION include/internal)
+install(DIRECTORY include
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING
+    PATTERN *.h
+    PATTERN *.tpp
+)
 
 ########################
 # googletest for unit testing

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -1,16 +1,22 @@
 cmake_minimum_required(VERSION 3.16)
 project(streets_service_base)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-
 include(dependencies.cmake)
-
-add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
 
 add_library(streets_service_base_lib
   src/streets_configuration_exception.cpp
   src/configuration.cpp
   src/streets_configuration.cpp
+)
+
+target_compile_definitions(streets_service_base_lib
+  PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE
+)
+
+target_compile_options(streets_service_base_lib
+  PRIVATE
+    -fPIC
 )
 
 target_include_directories(streets_service_base_lib
@@ -66,7 +72,6 @@ install(FILES ${templates} DESTINATION include/internal)
 ########################
 # googletest for unit testing
 ########################
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 set(BINARY streets_service_base_test)
 file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.h test/*.cpp)
 set(SOURCES ${TEST_SOURCES} WORKING_DIRECTORY  ${PROJECT_SOURCE_DIR}/test)
@@ -75,6 +80,16 @@ add_executable(${BINARY} ${TEST_SOURCES}
   src/streets_configuration_exception.cpp
   src/configuration.cpp
   src/streets_configuration.cpp
+)
+
+target_compile_definitions(${BINARY}
+  PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_ERROR
+)
+
+target_compile_options(${BINARY}
+  PRIVATE
+    -pthread
 )
 
 add_test(NAME ${BINARY} COMMAND ${BINARY})

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -39,7 +39,7 @@ file(GLOB files ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
 file(GLOB templates ${CMAKE_CURRENT_SOURCE_DIR}/include/internal/*.tpp)
 
 install(
-    TARGETS streets_service_base_lib
+    TARGETS streets_service_base_lib spdlog
     EXPORT streets_service_base_libTargets
     LIBRARY DESTINATION lib
     INCLUDES DESTINATION include

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -40,9 +40,6 @@ target_link_libraries(streets_service_base_lib
 ########################################################
 # Install streets_service_base_lib package.
 ########################################################
-file(GLOB files ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
-file(GLOB templates ${CMAKE_CURRENT_SOURCE_DIR}/include/internal/*.tpp)
-
 install(TARGETS streets_service_base_lib
   EXPORT streets_service_base_libTargets
   INCLUDES
@@ -81,30 +78,24 @@ install(DIRECTORY include
 ########################
 # googletest for unit testing
 ########################
-set(BINARY streets_service_base_test)
-file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.h test/*.cpp)
-set(SOURCES ${TEST_SOURCES} WORKING_DIRECTORY  ${PROJECT_SOURCE_DIR}/test)
-
-add_executable(${BINARY} ${TEST_SOURCES}
-  src/streets_configuration_exception.cpp
-  src/configuration.cpp
-  src/streets_configuration.cpp
+add_executable(streets_service_base_test
+  test/test_main.cpp
+  test/test_streets_configuration.cpp
+  test/test_streets_singleton.cpp
 )
 
-target_compile_definitions(${BINARY}
+target_compile_definitions(streets_service_base_test
   PRIVATE
     SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_ERROR
 )
 
-target_compile_options(${BINARY}
+target_include_directories(streets_service_base_test
   PRIVATE
-    -pthread
+    ${PROJECT_SOURCE_DIR}/include
 )
 
-add_test(NAME ${BINARY} COMMAND ${BINARY})
-target_include_directories(${BINARY} PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(${BINARY}
-  PUBLIC
+target_link_libraries(streets_service_base_test
+  PRIVATE
     Boost::system
     Boost::thread
     Boost::filesystem
@@ -112,3 +103,5 @@ target_link_libraries(${BINARY}
     GTest::GTest
     streets_service_base_lib
 )
+
+gtest_discover_tests(streets_service_base_test)

--- a/streets_utils/streets_service_base/cmake/streets_service_base_libConfig.cmake
+++ b/streets_utils/streets_service_base/cmake/streets_service_base_libConfig.cmake
@@ -1,7 +1,8 @@
-@PACKAGE_INIT@
-
 include(CMakeFindDependencyMacro)
-find_dependency(Boost 1.65.1 COMPONENTS system filesystem thread REQUIRED)
-find_dependency(spdlog REQUIRED)
 
-include("${CMAKE_CURRENT_LIST_DIR}/streets_service_base_libTargets.cmake")
+find_dependency(Boost 1.65.1 COMPONENTS system filesystem thread REQUIRED)
+find_dependency(RapidJSON REQUIRED)
+find_dependency(spdlog REQUIRED)
+find_dependency(GTest)
+
+include(${CMAKE_CURRENT_LIST_DIR}/streets_service_base_libTargets.cmake)

--- a/streets_utils/streets_service_base/dependencies.cmake
+++ b/streets_utils/streets_service_base/dependencies.cmake
@@ -5,13 +5,6 @@ FetchContent_Declare(rapidjson
     GIT_TAG 06d58b9e848c650114556a23294d0b6440078c61  # Top-level project requires post 1.1.0 (latest release) features
 )
 
-FetchContent_Declare(spdlog
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.10.0
-)
-
-FetchContent_MakeAvailable(spdlog)
-
 FetchContent_GetProperties(rapidjson)
 if(NOT rapidjson_POPULATED)
     FetchContent_Populate(rapidjson)
@@ -26,3 +19,7 @@ if(NOT rapidjson_POPULATED)
 
     add_subdirectory(${rapidjson_SOURCE_DIR} ${rapidjson_BINARY_DIR})
 endif()
+
+find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
+find_package(spdlog 1.10.0 EXACT REQUIRED)
+find_package(GTest REQUIRED MODULE)

--- a/streets_utils/streets_service_base/dependencies.cmake
+++ b/streets_utils/streets_service_base/dependencies.cmake
@@ -1,25 +1,4 @@
-include(FetchContent)
-
-FetchContent_Declare(rapidjson
-    GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
-    GIT_TAG 06d58b9e848c650114556a23294d0b6440078c61  # Top-level project requires post 1.1.0 (latest release) features
-)
-
-FetchContent_GetProperties(rapidjson)
-if(NOT rapidjson_POPULATED)
-    FetchContent_Populate(rapidjson)
-
-    # RapidJSON builds GTest by source, which conflicts with the source build in the top-level project. Since we do not
-    # need to test RapidJSON, we disable tests, examples, and docs.
-
-    set(RAPIDJSON_BUILD_DOC OFF CACHE INTERNAL "")
-    set(RAPIDJSON_BUILD_EXAMPLES OFF CACHE INTERNAL "")
-    set(RAPIDJSON_BUILD_TESTS OFF CACHE INTERNAL "")
-    set(RAPIDJSON_BUILD_THIRDPARTY_GTEST OFF CACHE INTERNAL "")
-
-    add_subdirectory(${rapidjson_SOURCE_DIR} ${rapidjson_BINARY_DIR})
-endif()
-
+find_package(RapidJSON REQUIRED)
 find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
 find_package(spdlog 1.10.0 EXACT REQUIRED)
 find_package(GTest REQUIRED MODULE)

--- a/streets_utils/streets_service_base/dependencies.cmake
+++ b/streets_utils/streets_service_base/dependencies.cmake
@@ -1,5 +1,5 @@
 find_package(RapidJSON REQUIRED)
-find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
+find_package(Boost COMPONENTS system filesystem thread REQUIRED)
 find_package(spdlog 1.10.0 EXACT REQUIRED)
 
 if(STREETSSERVICEBASE_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)

--- a/streets_utils/streets_service_base/dependencies.cmake
+++ b/streets_utils/streets_service_base/dependencies.cmake
@@ -1,0 +1,28 @@
+include(FetchContent)
+
+FetchContent_Declare(rapidjson
+    GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
+    GIT_TAG 06d58b9e848c650114556a23294d0b6440078c61  # Top-level project requires post 1.1.0 (latest release) features
+)
+
+FetchContent_Declare(spdlog
+    GIT_REPOSITORY https://github.com/gabime/spdlog.git
+    GIT_TAG v1.10.0
+)
+
+FetchContent_MakeAvailable(spdlog)
+
+FetchContent_GetProperties(rapidjson)
+if(NOT rapidjson_POPULATED)
+    FetchContent_Populate(rapidjson)
+
+    # RapidJSON builds GTest by source, which conflicts with the source build in the top-level project. Since we do not
+    # need to test RapidJSON, we disable tests, examples, and docs.
+
+    set(RAPIDJSON_BUILD_DOC OFF CACHE INTERNAL "")
+    set(RAPIDJSON_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+    set(RAPIDJSON_BUILD_TESTS OFF CACHE INTERNAL "")
+    set(RAPIDJSON_BUILD_THIRDPARTY_GTEST OFF CACHE INTERNAL "")
+
+    add_subdirectory(${rapidjson_SOURCE_DIR} ${rapidjson_BINARY_DIR})
+endif()

--- a/streets_utils/streets_service_base/dependencies.cmake
+++ b/streets_utils/streets_service_base/dependencies.cmake
@@ -1,4 +1,7 @@
 find_package(RapidJSON REQUIRED)
 find_package(Boost 1.71.0 EXACT COMPONENTS system filesystem thread REQUIRED)
 find_package(spdlog 1.10.0 EXACT REQUIRED)
-find_package(GTest REQUIRED MODULE)
+
+if(STREETSSERVICEBASE_ENABLE_TESTING OR PROJECT_IS_TOP_LEVEL)
+  find_package(GTest REQUIRED)
+endif()

--- a/streets_utils/streets_service_base/src/CMakeLists.txt
+++ b/streets_utils/streets_service_base/src/CMakeLists.txt
@@ -1,0 +1,59 @@
+include(GNUInstallDirs)
+
+add_library(streets_service_base_lib
+  streets_configuration_exception.cpp
+  configuration.cpp
+  streets_configuration.cpp
+)
+
+add_library(streets_service_base_lib::streets_service_base_lib ALIAS streets_service_base_lib)
+
+target_compile_definitions(streets_service_base_lib
+  PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE
+)
+
+target_compile_options(streets_service_base_lib
+  PRIVATE
+    -fPIC
+)
+
+target_include_directories(streets_service_base_lib
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+
+target_link_libraries(streets_service_base_lib
+  PUBLIC
+    Boost::system
+    Boost::thread
+    Boost::filesystem
+    spdlog::spdlog
+)
+
+install(TARGETS streets_service_base_lib
+  EXPORT streets_service_base_libTargets
+  INCLUDES
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  LIBRARY
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(EXPORT streets_service_base_libTargets
+  FILE streets_service_base_libTargets.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/streets_service_base_lib
+  NAMESPACE streets_service_base_lib::
+)
+
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/streets_service_base_libConfig.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/streets_service_base_lib/
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING
+    PATTERN *.h
+    PATTERN *.tpp
+)

--- a/streets_utils/streets_service_base/src/CMakeLists.txt
+++ b/streets_utils/streets_service_base/src/CMakeLists.txt
@@ -1,5 +1,16 @@
 include(GNUInstallDirs)
 
+set(STREETSSERVICEBASE_SPDLOG_LEVEL SPDLOG_LEVEL_WARN CACHE STRING "Logging level for spdlog")
+set_property(CACHE STREETSSERVICEBASE_SPDLOG_LEVEL PROPERTY STRINGS
+  SPDLOG_LEVEL_TRACE
+  SPDLOG_LEVEL_DEBUG
+  SPDLOG_LEVEL_INFO
+  SPDLOG_LEVEL_WARN
+  SPDLOG_LEVEL_ERROR
+  SPDLOG_LEVEL_CRITICAL
+  SPDLOG_LEVEL_OFF
+)
+
 add_library(streets_service_base_lib
   streets_configuration_exception.cpp
   configuration.cpp
@@ -10,7 +21,7 @@ add_library(streets_service_base_lib::streets_service_base_lib ALIAS streets_ser
 
 target_compile_definitions(streets_service_base_lib
   PRIVATE
-    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE
+    SPDLOG_ACTIVE_LEVEL=${STREETSSERVICEBASE_SPDLOG_LEVEL}
 )
 
 target_compile_options(streets_service_base_lib

--- a/streets_utils/streets_service_base/test/CMakeLists.txt
+++ b/streets_utils/streets_service_base/test/CMakeLists.txt
@@ -4,11 +4,6 @@ add_executable(streets_service_base_test
   test_streets_singleton.cpp
 )
 
-target_compile_definitions(streets_service_base_test
-  PRIVATE
-    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_ERROR
-)
-
 target_include_directories(streets_service_base_test
   PRIVATE
     ${PROJECT_SOURCE_DIR}/include

--- a/streets_utils/streets_service_base/test/CMakeLists.txt
+++ b/streets_utils/streets_service_base/test/CMakeLists.txt
@@ -4,11 +4,6 @@ add_executable(streets_service_base_test
   test_streets_singleton.cpp
 )
 
-target_include_directories(streets_service_base_test
-  PRIVATE
-    ${PROJECT_SOURCE_DIR}/include
-)
-
 target_link_libraries(streets_service_base_test
   PRIVATE
     Boost::system

--- a/streets_utils/streets_service_base/test/CMakeLists.txt
+++ b/streets_utils/streets_service_base/test/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_executable(streets_service_base_test
+  test_main.cpp
+  test_streets_configuration.cpp
+  test_streets_singleton.cpp
+)
+
+target_compile_definitions(streets_service_base_test
+  PRIVATE
+    SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_ERROR
+)
+
+target_include_directories(streets_service_base_test
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+target_link_libraries(streets_service_base_test
+  PRIVATE
+    Boost::system
+    Boost::thread
+    Boost::filesystem
+    spdlog::spdlog
+    GTest::GTest
+    streets_service_base_lib::streets_service_base_lib
+)
+
+# The CI system expects the test binary to be in the project's binary root directory
+set_target_properties(streets_service_base_test
+  PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
+)
+
+gtest_discover_tests(streets_service_base_test)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR addresses issue #236 by modernizing and cleaning up the project's CMake configuration. 

The biggest change is architecture. Package dependencies have been moved into a `dependencies.cmake` file to clean up the top-level `CMakeLists.txt` file. All commands related to building the `streets_service_base` library have been moved to `src/CMakeLists.txt`, again to clean up the top-level file. Finally, all test-related commands have been moved to `test/CMakeLists.txt`. The architectural changes are based on the recommended project structure in Craig Scott's Professional CMake book (Section 34.2 in the 13th edition).

Other general changes include moving global configurations to target-based ones to avoid unintended and undesirable behaviors. For example, setting compiler flags.

The CMake version is updated to 3.16, which is the version available in Ubuntu 20.04's `apt` repos. With an upgraded version, we can better utilize new CMake features. Configuration options were added to allow consumers to decided on building tests and setting the spdlog logging level. Additionally, tests will not build by default if the project is consumed as a subproject into another project. Consumers can override this if they desire.

If there is a design decision that seems unclear, please check my commit messages. I tried to explain my reasoning/justification in them.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #236

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

CMake brings a lot of historical baggage and complexities that developers are trying to address in newer releases. Therefore, it is good project hygiene to periodically review and clean out old CMake usages for better practices. This PR is an attempt to do that.

For a non-technical motivation, I wanted to work on a non-trivial CMake project while also contributing to an open-source project.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I built the project in a clean environment and ran the unit tests. Everything seemed to work fine.

I built some consumer projects, and those seemed to build without issues. I have not tested final `_service` packages due to other dependency/build challenges. However, direct consumers of `streets_service_base` seem to build fine with the new changes.

I took care to ensure the unit test executable is put where the CI scripts expect it to be, so it should not affect that process. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
