### PR TITLE
add conversion units

### DIFF
--- a/message_services/src/services/vehicle_status_intent_service.cpp
+++ b/message_services/src/services/vehicle_status_intent_service.cpp
@@ -113,7 +113,6 @@ namespace message_services
             std::shared_ptr<message_services::workers::bsm_worker> bsm_w_ptr = std::make_shared<message_services::workers::bsm_worker>();
             std::shared_ptr<message_services::workers::mobilitypath_worker> mp_w_ptr = std::make_shared<message_services::workers::mobilitypath_worker>();
             std::shared_ptr<message_services::workers::mobilityoperation_worker> mo_w_ptr = std::make_shared<message_services::workers::mobilityoperation_worker>();
-            std::shared_ptr<message_services::workers::vehicle_status_intent_worker> vsi_w_ptr = std::make_shared<message_services::workers::vehicle_status_intent_worker>();
             run(bsm_w_ptr, mp_w_ptr, mo_w_ptr);
         }
 
@@ -264,8 +263,8 @@ namespace message_services
 
                 // Update vehicle status intent with BSM
                 vsi.setVehicle_length(bsm.getCore_data().size.length);
-                vsi.setCur_speed(bsm.getCore_data().speed);
-                vsi.setCur_accel(bsm.getCore_data().accelSet.Long);
+                vsi.setCur_speed(bsm.getCore_data().speed * 0.02); //convert to mps
+                vsi.setCur_accel(bsm.getCore_data().accelSet.Long * 0.01); //convert to mps2
                 std::string turn_direction = mo.get_value_from_strategy_params("turn_direction");
                 vsi.SetTurn_direction(turn_direction);
                 double cur_lat = bsm.getCore_data().latitude / 10000000;

--- a/signal_opt_service/test/test_signal_opt_messages_worker.cpp
+++ b/signal_opt_service/test/test_signal_opt_messages_worker.cpp
@@ -28,8 +28,8 @@ TEST(signal_opt_messages_worker, update_vehicle_list)
     ASSERT_EQ(3, vehicle_list_ptr->get_vehicles().size());
 
     // Update vehicles
-    ASSERT_EQ(5, vehicle_list_ptr->get_vehicles().at("DOT-507")._cur_speed / 0.02);
-    ASSERT_EQ(5, vehicle_list_ptr->get_vehicles().at("DOT-508")._cur_speed / 0.02);
+    ASSERT_EQ(5, vehicle_list_ptr->get_vehicles().at("DOT-507")._cur_speed);
+    ASSERT_EQ(5, vehicle_list_ptr->get_vehicles().at("DOT-508")._cur_speed);
 
     cur_time += 1000;
     vsi_payload = "{ \"metadata\": { \"timestamp\": " + std::to_string(cur_time) + " }, \"payload\": { \"v_id\": \"DOT-507\", \"v_length\": 5, \"min_gap\": 15.0, \"react_t\": 2, \"max_accel\": 5.0, \"max_decel\": 5.0, \"cur_speed\": 10.0, \"cur_accel\": 0.0, \"cur_lane_id\": 7, \"cur_ds\": 7.0, \"direction\": \"straight\", \"entry_lane_id\": 7, \"link_lane_id\": 8, \"dest_lane_id\": 9, \"is_allowed\": false, \"depart_pos\": 1, \"est_paths\": [{ \"ts\": 1623677096200, \"id\": 7, \"ds\": 6.0 }, { \"ts\": 1623677096400, \"id\": 7, \"ds\": 5.0 }, { \"ts\": 1623677096600, \"id\": 7, \"ds\": 4.0 }, { \"ts\": 1623677096800, \"id\": 7, \"ds\": 3.0 }, { \"ts\": 1623677097000, \"id\": 7, \"ds\": 2.0 } ] } }";
@@ -40,8 +40,8 @@ TEST(signal_opt_messages_worker, update_vehicle_list)
     so_msgs_worker_ptr->update_vehicle_list(vsi_payload, vehicle_list_ptr);
     ASSERT_EQ(3, vehicle_list_ptr->get_vehicles().size());
 
-    ASSERT_EQ(10, vehicle_list_ptr->get_vehicles()["DOT-507"]._cur_speed / 0.02);
-    ASSERT_EQ(20, vehicle_list_ptr->get_vehicles()["DOT-508"]._cur_speed / 0.02);
+    ASSERT_EQ(10, vehicle_list_ptr->get_vehicles()["DOT-507"]._cur_speed);
+    ASSERT_EQ(20, vehicle_list_ptr->get_vehicles()["DOT-508"]._cur_speed);
 }
 
 TEST(signal_opt_messages_worker, request_intersection_info)

--- a/streets_utils/streets_vehicle_list/src/message_processors/all_stop_status_intent_processor.cpp
+++ b/streets_utils/streets_vehicle_list/src/message_processors/all_stop_status_intent_processor.cpp
@@ -96,11 +96,8 @@ namespace streets_vehicles {
 		}
 
 			
-		/* the unit of the received speed from the message is 0.02 of meter per second
-		*  the unit of the speed defined in the vehicle class is meter per second. 
-		*/
 		if (payload.FindMember("cur_speed")->value.IsDouble()){
-			vehicle._cur_speed = payload["cur_speed"].GetDouble() * 0.02;
+			vehicle._cur_speed = payload["cur_speed"].GetDouble();
 		} else{
 			throw status_intent_processing_exception("The \"cur_speed\" " + vehicle._id + " is missing/incorrect in received update!");
 		}

--- a/streets_utils/streets_vehicle_scheduler/test/test_all_stop_json_csv_schedule.cpp
+++ b/streets_utils/streets_vehicle_scheduler/test/test_all_stop_json_csv_schedule.cpp
@@ -158,6 +158,7 @@ TEST_F(all_stop_json_csv_schedule_test, csv_schedule){
     schedule.vehicle_schedules.push_back(sched3);
 
     int new_lines = boost::count( schedule.toCSV(), '\n');
-    ASSERT_EQ( new_lines, 3);
+    //New line after each schedule
+    ASSERT_EQ( new_lines, 2);
 
 }

--- a/streets_utils/streets_vehicle_scheduler/test/test_signalized_json_csv_schedule.cpp
+++ b/streets_utils/streets_vehicle_scheduler/test/test_signalized_json_csv_schedule.cpp
@@ -150,6 +150,7 @@ TEST_F(signalized_json_csv_schedule_test, csv_schedule){
     schedule.vehicle_schedules.push_back(sched4);
 
     int new_lines = boost::count( schedule.toCSV(), '\n');
-    ASSERT_EQ( new_lines, 4);
+    //New line after each schedule
+    ASSERT_EQ( new_lines, 3);
 
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Fixes https://github.com/usdot-fhwa-stol/carma-streets/issues/249

This PR fixes an issue with parsing speed and acceleration from incoming bsm messages to vehicle_status_and_intent messages.
Both of these values come in, in J2735 units and need to be converted to SI units before being used.
Current implementation converts the speed correctly in streets_utils. Since this implementation should be done in message_services where the bsm message is being read, it is moved there.

This PR also removes initialization of an unused class being called in message_services.

## Description

<!--- Describe your changes in detail -->

## Related Issue
Issue #249 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
