### PR TITLE
#271: update desired phase plan if events expired

### DIFF
--- a/streets_utils/streets_signal_phase_and_timing/src/models/spat.cpp
+++ b/streets_utils/streets_signal_phase_and_timing/src/models/spat.cpp
@@ -139,7 +139,7 @@ namespace signal_phase_and_timing{
         intersections.front().clear_future_movement_events();
         auto states = intersections.front().states;
         // Loop through desired phase plan
-        bool is_procssing_first_desired_green = true;
+        bool is_processing_first_desired_green = true;
         for (const auto &desired_sg_green_timing : candidate_dpp.desired_phase_plan)
         {
             if (desired_sg_green_timing.signal_groups.empty())
@@ -161,7 +161,7 @@ namespace signal_phase_and_timing{
                 // Get movement_state by reference. With this reference, it can update the original SPAT movement state list
                 auto &cur_movement_state_ref = intersections.front().get_movement(current_signal_group_id);
                 // Processing the next current or first desired future movement event from the desired phase plan
-                if (is_procssing_first_desired_green)
+                if (is_processing_first_desired_green)
                 {
                    process_first_desired_green(cur_movement_state_ref, desired_sg_green_timing, tsc_state);
                 }
@@ -171,7 +171,7 @@ namespace signal_phase_and_timing{
                     process_second_onward_desired_green(cur_movement_state_ref, desired_sg_green_timing, tsc_state);
                 }
             }
-            is_procssing_first_desired_green = false;
+            is_processing_first_desired_green = false;
         }
     }
 

--- a/tsc_client_service/src/monitor_desired_phase_plan.cpp
+++ b/tsc_client_service/src/monitor_desired_phase_plan.cpp
@@ -20,7 +20,7 @@ namespace traffic_signal_controller_service
     {
         if (tsc_state_ptr == nullptr || spat_ptr == nullptr || tsc_state_ptr->get_tsc_config_state() == nullptr)
         {
-            throw monitor_desired_phase_plan_exception("SPAT and TSC state pointers cannot be null. SKIP prcessing!");
+            throw monitor_desired_phase_plan_exception("SPAT and TSC state pointers cannot be null. SKIP processing!");
         }
 
         if (spat_ptr->get_intersection().states.empty())
@@ -43,6 +43,20 @@ namespace traffic_signal_controller_service
                 fix_upcoming_green(spat_ptr, tsc_state_ptr);
             }
         } else {
+
+            // Loop through the desired phase plan and remove an event if the end time is past current
+            bool no_expired_events = false;
+            while(!no_expired_events){
+                // Check first event in desired phase plan and remove if expired
+                uint64_t cur_time_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+                if(cur_time_since_epoch < desired_phase_plan_ptr->desired_phase_plan.front().end_time){
+                    no_expired_events = true;
+                }
+                else{
+                    desired_phase_plan_ptr->desired_phase_plan.erase(desired_phase_plan_ptr->desired_phase_plan.begin());
+                }
+            }
+
             spat_ptr->update_spat_with_candidate_dpp(*desired_phase_plan_ptr, tsc_state_ptr->get_tsc_config_state());
         }
     }

--- a/tsc_client_service/test/test_monitor_desired_phase_plan.cpp
+++ b/tsc_client_service/test/test_monitor_desired_phase_plan.cpp
@@ -496,7 +496,7 @@ namespace traffic_signal_controller_service
             monitor_dpp_ptr->update_spat_future_movement_events(nullptr, nullptr);
         }
         catch( const monitor_desired_phase_plan_exception &e ) {
-            ASSERT_STREQ(e.what(), "SPAT and TSC state pointers cannot be null. SKIP prcessing!");
+            ASSERT_STREQ(e.what(), "SPAT and TSC state pointers cannot be null. SKIP processing!");
         }
         // Initialize tsc_state
         mock_tsc_ntcip();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR fixes an issue in the TSC service where the desired phase plan pointer keeps the last received desired phase plan even if the events are expired.
The fix implemented is, on every new spat update if there a non-null desired phase pointer, its events are checked to see if they have expired. If they have, the expired events are removed.

## Description

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-streets/issues/271

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
