### PR TITLE
convert_spat_to_dpp in dpp_generator returns wrong movement group sequence

### DIFF
--- a/streets_utils/streets_signal_optimization/src/streets_desired_phase_plan_generator.cpp
+++ b/streets_utils/streets_signal_optimization/src/streets_desired_phase_plan_generator.cpp
@@ -217,6 +217,11 @@ namespace streets_signal_optimization {
                 base_desired_phase_plan.desired_phase_plan.push_back(mg_green);
             }
             else {
+                /** 
+                 * is_added parameter checks if mg_green has been added to the base_desired_phase_plan 
+                 *      somewhere before the last existing movement_group. If this parameter is false at the end of
+                 *      the for loop, mg_green must be added to the end of the list.
+                 */
                 bool is_added = false;
                 for (int index = 0; index < base_desired_phase_plan.desired_phase_plan.size(); ++index) {
                     if ( (mg_green.start_time < base_desired_phase_plan.desired_phase_plan[index].start_time && 
@@ -231,6 +236,10 @@ namespace streets_signal_optimization {
                         break;
                     }
                 }
+                /**
+                 * If is_added is false, mg_green is not added to the base_desired_phase_plan which means that mg_green
+                 *      must be added to the end of the list!
+                */
                 if (!is_added) {
                     base_desired_phase_plan.desired_phase_plan.push_back(mg_green);
                 }

--- a/streets_utils/streets_signal_optimization/src/streets_desired_phase_plan_generator.cpp
+++ b/streets_utils/streets_signal_optimization/src/streets_desired_phase_plan_generator.cpp
@@ -217,6 +217,7 @@ namespace streets_signal_optimization {
                 base_desired_phase_plan.desired_phase_plan.push_back(mg_green);
             }
             else {
+                bool is_added = false;
                 for (int index = 0; index < base_desired_phase_plan.desired_phase_plan.size(); ++index) {
                     if ( (mg_green.start_time < base_desired_phase_plan.desired_phase_plan[index].start_time && 
                                 mg_green.end_time > base_desired_phase_plan.desired_phase_plan[index].start_time) || 
@@ -226,12 +227,12 @@ namespace streets_signal_optimization {
                     }
                     if (mg_green.end_time < base_desired_phase_plan.desired_phase_plan[index].start_time) {
                         base_desired_phase_plan.desired_phase_plan.insert(base_desired_phase_plan.desired_phase_plan.begin() + index, mg_green);
+                        is_added = true;
                         break;
                     }
-                    if (mg_green.start_time > base_desired_phase_plan.desired_phase_plan[index].end_time) {
-                        base_desired_phase_plan.desired_phase_plan.insert(base_desired_phase_plan.desired_phase_plan.begin() + index + 1, mg_green);
-                        break;
-                    }
+                }
+                if (!is_added) {
+                    base_desired_phase_plan.desired_phase_plan.push_back(mg_green);
                 }
             }
         }
@@ -322,7 +323,7 @@ namespace streets_signal_optimization {
         for ( const auto &entry_lane_obj : intersection_info_ptr->getEntryLanelets() ) {
             std::list<streets_vehicle_scheduler::signalized_vehicle_schedule> schedules_in_lane;
             for ( const auto &ev_sched : ev_schedules_within_so.vehicle_schedules ) {
-                if (ev_sched.state == streets_vehicles::vehicle_state::EV && ev_sched.entry_lane == entry_lane_obj.getId() && ev_sched.et > tbd_start) {
+                if (ev_sched.state == streets_vehicles::vehicle_state::EV && ev_sched.entry_lane == entry_lane_obj.getId() && ev_sched.et >= tbd_start) {
                     SPDLOG_DEBUG("Adding schedule for vehicle {0} to EV schedule list in entry lane {1}", ev_sched.v_id, ev_sched.entry_lane);
                     schedules_in_lane.push_back(ev_sched);
                 }

--- a/streets_utils/streets_signal_optimization/test/test_streets_desired_phase_plan_generator.cpp
+++ b/streets_utils/streets_signal_optimization/test/test_streets_desired_phase_plan_generator.cpp
@@ -176,6 +176,23 @@ TEST(test_streets_desired_phase_plan_generator, test_convert_spat_to_dpp) {
 
     ASSERT_THROW(generator.convert_spat_to_dpp(intersection_state, move_groups), streets_desired_phase_plan_generator_exception);
 
+
+    // case with 2 greens from the same signal group!
+    move_groups->groups.front().signal_groups.second = 0;
+    move_groups->groups.front().signal_groups.first = 3;
+    movement_group mg4;
+    mg4.name = "movement_group_4";
+    mg4.signal_groups = {1, 0};
+    move_groups->groups.push_back(mg4);
+    
+    std::string json_spat_2green = "{\"timestamp\":0,\"name\":\"West Intersection\",\"intersections\":[{\"name\":\"West Intersection\",\"id\":1909,\"status\":0,\"revision\":123,\"moy\":34232,\"time_stamp\":130,\"enabled_lanes\":[9, 10, 11, 12, 13, 14, 15, 16],\"states\":[{\"movement_name\":\"All Directions\",\"signal_group\":1,\"state_time_speed\":[{\"event_state\":6,\"timing\":{\"start_time\":9950,\"min_end_time\":10100}},{\"event_state\":8,\"timing\":{\"start_time\":10100,\"min_end_time\":10130}}, {\"event_state\":3,\"timing\":{\"start_time\":10130,\"min_end_time\":10300}},{\"event_state\":6,\"timing\":{\"start_time\":10300,\"min_end_time\":10400}},{\"event_state\":8,\"timing\":{\"start_time\":10400,\"min_end_time\":10430}}, {\"event_state\":3,\"timing\":{\"start_time\":10430,\"min_end_time\":10450}}]},{\"movement_name\":\"All Directions\",\"signal_group\":2,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":9950,\"min_end_time\":10150}},{\"event_state\":6,\"timing\":{\"start_time\":10150,\"min_end_time\":10250}}, {\"event_state\":8,\"timing\":{\"start_time\":10250,\"min_end_time\":10280}}, {\"event_state\":3,\"timing\":{\"start_time\":10280,\"min_end_time\":10450}}]},{\"movement_name\":\"All Directions\",\"signal_group\":3,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":9950,\"min_end_time\":10450}}]}, {\"movement_name\":\"All Directions\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":9950,\"min_end_time\":10450}}]}],\"maneuver_assist_list\":[{\"connection_id\":7,\"queue_length\":4,\"available_storage_length\":8,\"wait_on_stop\":true,\"ped_bicycle_detect\":false}]}]}";
+    spat_object.fromJson(json_spat_2green);
+    intersection_state = spat_object.get_intersection();
+    base_desired_phase_plan = generator.convert_spat_to_dpp(intersection_state, move_groups);
+    ASSERT_EQ( base_desired_phase_plan.desired_phase_plan.size(), 3);
+    SPDLOG_INFO("converted spat to dpp: {0}", base_desired_phase_plan.toJson());
+    ASSERT_EQ( base_desired_phase_plan.desired_phase_plan.front().signal_groups.front(), 1);
+    ASSERT_EQ( base_desired_phase_plan.desired_phase_plan.back().signal_groups.front(), 1);
 }
 
 

--- a/streets_utils/streets_signal_optimization/test/test_streets_desired_phase_plan_generator.cpp
+++ b/streets_utils/streets_signal_optimization/test/test_streets_desired_phase_plan_generator.cpp
@@ -177,7 +177,16 @@ TEST(test_streets_desired_phase_plan_generator, test_convert_spat_to_dpp) {
     ASSERT_THROW(generator.convert_spat_to_dpp(intersection_state, move_groups), streets_desired_phase_plan_generator_exception);
 
 
-    // case with 2 greens from the same signal group!
+    /**
+     * Case with 2 greens from the same signal group!
+     * Movement group sequence from spat:  [signal group 1 {9950, 10100}, 
+     *                                      signal group 2 {10150, 10250}, 
+     *                                      signal group 1 {10350, 10450}]
+     * Movement_group_list: [Movement group 1 {signal group 3, 0}, 
+     *                       Movement group 2 {signal group 2, 0},
+     *                       Movement group 3 {signal group 4, 0},
+     *                       Movement group 4 {signal group 1, 0},]
+     */ 
     move_groups->groups.front().signal_groups.second = 0;
     move_groups->groups.front().signal_groups.first = 3;
     movement_group mg4;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Depending on the sequence of available movement groups in the movement group list, the convert_spat_to_dpp method in streets_desired_phase_plan_generator might make a mistake in the converting spat to dpp and might not return the correct sequence of movement groups.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-streets/issues/284

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
