### PR TITLE
289 update snmp timeout

### DIFF
--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -73,8 +73,8 @@ class snmp_client
         /* net-snmp version definition: SNMP_VERSION_1:0 SNMP_VERSION_2c:1 SNMP_VERSION_2u:2 SNMP_VERSION_3:3 
         https://github.com/net-snmp/net-snmp/blob/master/include/net-snmp/library/snmp.h */
         int snmp_version_ = 0;
-        /*Time after which the the snmp request times out*/
-        int timeout_ = 10000;
+        /*Time after which the the snmp request times out 15 ms or 15000 micro seconds*/
+        int timeout_ = 15000;
 
 
     public:

--- a/tsc_client_service/include/snmp_client.h
+++ b/tsc_client_service/include/snmp_client.h
@@ -73,8 +73,6 @@ class snmp_client
         /* net-snmp version definition: SNMP_VERSION_1:0 SNMP_VERSION_2c:1 SNMP_VERSION_2u:2 SNMP_VERSION_3:3 
         https://github.com/net-snmp/net-snmp/blob/master/include/net-snmp/library/snmp.h */
         int snmp_version_ = 0;
-        /*Time after which the the snmp request times out 15 ms or 15000 micro seconds*/
-        int timeout_ = 15000;
 
 
     public:

--- a/tsc_client_service/manifest.json
+++ b/tsc_client_service/manifest.json
@@ -28,9 +28,9 @@
             "type": "INTEGER" 
         },
         {
-            "name": "timeout",
-            "value": 10000,
-            "description": "Time in millisecond after which the the snmp request times out",
+            "name": "snmp_timeout",
+            "value": 15000,
+            "description": "Time in microseconds after which the the snmp request times out",
             "type": "INTEGER" 
         },
         {

--- a/tsc_client_service/src/snmp_client.cpp
+++ b/tsc_client_service/src/snmp_client.cpp
@@ -4,7 +4,7 @@ namespace traffic_signal_controller_service
 {
     
     snmp_client::snmp_client(const std::string& ip, const int& port, const std::string& community, int snmp_version, int timeout)
-        : ip_(ip), port_(port), community_(community),snmp_version_(snmp_version), timeout_(timeout)
+        : ip_(ip), port_(port), community_(community),snmp_version_(snmp_version)
     {
         
         SPDLOG_DEBUG("Starting SNMP Client");
@@ -28,7 +28,7 @@ namespace traffic_signal_controller_service
         
         session.community = comm;
         session.community_len = community_.length();
-        session.timeout = timeout_;
+        session.timeout = timeout;
         session.retries = 0;
 
         ss = snmp_open(&session);

--- a/tsc_client_service/src/snmp_client.cpp
+++ b/tsc_client_service/src/snmp_client.cpp
@@ -28,6 +28,7 @@ namespace traffic_signal_controller_service
         
         session.community = comm;
         session.community_len = community_.length();
+        // Timeout is in microseconds
         session.timeout = timeout;
         session.retries = 0;
 

--- a/tsc_client_service/src/tsc_service.cpp
+++ b/tsc_client_service/src/tsc_service.cpp
@@ -34,7 +34,7 @@ namespace traffic_signal_controller_service {
             int target_port = streets_service::streets_configuration::get_int_config("target_port");
             std::string community = streets_service::streets_configuration::get_string_config("community");
             int snmp_version = streets_service::streets_configuration::get_int_config("snmp_version");
-            int timeout = streets_service::streets_configuration::get_int_config("timeout");
+            int timeout = streets_service::streets_configuration::get_int_config("snmp_timeout");
             if (!snmp_client_ptr) {
                 if  (!initialize_snmp_client(target_ip, target_port, community, snmp_version, timeout)) {
                     SPDLOG_ERROR("Failed to initialize snmp_client!");


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
<!--- Describe your changes in detail -->
Update `snmp_client` to make snmp timeout default to 15000 microseconds. Included updates to class to remove unnecessary class member as well as updating configuration parameter name and description to more accurately represent functionality
## Related Issue
#289 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Occasionally NTCIP GET NEXT PHASE GROUP commands sent during yellow change and red clearance intervals will timeout due to the 10 ms set timeout. This will cause the TSC to drop a single SPaT message. Increasing the default value of this parameter and cleaning up unnecessary class member/confusing configuration name/incorrect configuration description can help reduce the number of times we drop SPaT messages under these conditions. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested on VM Test Instance 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
