### PR TITLE
Prevent the calculated delays from being zero

### DIFF
--- a/streets_utils/streets_signal_optimization/src/streets_desired_phase_plan_arbitrator.cpp
+++ b/streets_utils/streets_signal_optimization/src/streets_desired_phase_plan_arbitrator.cpp
@@ -125,15 +125,9 @@ namespace streets_signal_optimization
             }
         }
 
-        float delay_measure = 0.0;
-        if (TBD_delay > 0)
-        {
-            delay_measure = (float)candidate_vehicles_delay / (float)TBD_delay;
-        }
-        else
-        {
-            delay_measure = (float)candidate_vehicles_delay;
-        }
+        // The minimum value of the calculated delay can be 1 millisecond.
+        float delay_measure = (float)std::max(candidate_vehicles_delay, u_int64_t(1)) / (float)std::max(TBD_delay, u_int64_t(1));
+
         SPDLOG_DEBUG("calculated delay_measure (= candidate/TBD) = {0}", delay_measure);
 
         if (enable_so_logging) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
The signal optimization logic creates different desired phase plan options based on the received vehicle information. For each desired phase plan option, the logic calculates a delay_measure. The delay measure is calculated with the following equation:

delay_measure = served_delay / tbd_delay
served_delay: the delay of all vehicles that can enter the intersection box during the new green phase in the created desired phase plan.
tbd_delay: the delay of all vehicles that cannot enter the intersection bod during any fixed phase in the created desired phase plan.

Once the delay_measure is calculated for all possible desired phase plans, the logic selects the desired phase plan with highest delay_measure.

Now the problem arises when there are 2 or more desired phase plan with maximum delay_measure. In this case, the logic just picks the one it sees first while going through all options sequentially which might not make sense. One of the case that this issue might happen more often is when the maximum delay_measure is equal to zero while we have more than one possible desired phase plan (note that it is possible to have a zero served_delay which causes the delay_measure to be zero regardless of tbd_delay).

While eventually a general tie breaker rule is needed when two or more desired phase plans have the same maximum delay_measure, a simpler fix would be protecting against zero delay_measure edge case. Basically, if there are more than one desired phase plan and the maximum delay_measure is zero (i.e., all delay_measures are zero!), then the logic should pick the desired phase plan with minimum tbd_delay rather than just picking the first one in the list.

As a Fix, we do not allow the delay_measure or the tbd_delay to be zero. If they are, we will set it to 1 (millisecond). In this case, if two or more desired phase plan have zero served_delay, the served_delay will be set to 1 and the tbd_delay will decide which desired phase plan shall be picked.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/usdot-fhwa-stol/carma-streets/issues/294

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
