### PR TITLE
Issue-290: Add mysql volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - mysql_root_password
     volumes:
       - ./mysql/localhost.sql:/docker-entrypoint-initdb.d/localhost.sql
-
+      - mysql-datavolume:/var/lib/mysql
   php:
     image: usdotfhwaops/php:latest
     container_name: php
@@ -79,8 +79,7 @@ services:
       - ./logs:/var/log/tmx
       - ./MAP:/var/www/plugins/MAP
       - /etc/localtime:/etc/localtime:ro
-      - /etc/timezone:/etc/timezone:ro
-      
+      - /etc/timezone:/etc/timezone:ro    
   scheduling_service:
     image: usdotfhwastoldev/scheduling_service:develop
     command: sh -c "/wait && /home/carma-streets/scheduling_service/build/scheduling_service"
@@ -196,4 +195,5 @@ secrets:
         file: ./secrets/mysql_password.txt
     mysql_root_password:
         file: ./secrets/mysql_root_password.txt
-
+volumes:
+    mysql-datavolume:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Add mysql name volume to persist DB state so that V2X-Hub plugin configurations and user credentials can be persisted between redeployments.
<!--- Describe your changes in detail -->

## Related Issue
#290
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Improve deployment process
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Deployed at West Intersection
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
