### PR TITLE
Added enable call to tsc_service initialization

### DIFF
--- a/tsc_client_service/src/tsc_service.cpp
+++ b/tsc_client_service/src/tsc_service.cpp
@@ -88,7 +88,10 @@ namespace traffic_signal_controller_service {
             {
                 configure_snmp_cmd_logger();
             }
-            enable_spat();
+            if (is_simulation_mode()) {
+                // Trigger spat broadcasting for EVC on startup.
+                enable_spat();
+            }
             SPDLOG_INFO("Traffic Signal Controller Service initialized successfully!");
             return true;
         }

--- a/tsc_client_service/src/tsc_service.cpp
+++ b/tsc_client_service/src/tsc_service.cpp
@@ -88,7 +88,7 @@ namespace traffic_signal_controller_service {
             {
                 configure_snmp_cmd_logger();
             }
-
+            enable_spat();
             SPDLOG_INFO("Traffic Signal Controller Service initialized successfully!");
             return true;
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Added enable spat SNMP command to tsc_service initiliazation. Command should not impact success outcome of initialization.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
For CDA Simulation testing with Virtual Signal Controller this NTCIP command needs to be execute each time on startup to enable SPaT forwarding
## How Has This Been Tested?
Integration tested in AWS cloud formation XIL environment. Functionality works although unrelated bug still causing segfaul.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
