### PR TITLE
Fix/carma clock wait initialization

### DIFF
--- a/scripts/dpp_script.py
+++ b/scripts/dpp_script.py
@@ -1,0 +1,110 @@
+import json
+import asyncio
+import sys
+from aiokafka import AIOKafkaConsumer
+from aiokafka import AIOKafkaProducer
+
+#The SimulationHelper class is used to create a Kafka Consumer and Producer. When the appropriate time_sync message is received
+#by the Consumer, the Producer sends a desired phase plan to the desired phase plan topic.
+class SimulationHelper():
+    #Initialize the SimulationHelper with the input Kafka IP address and port
+    def __init__(self, kafkaIP, kafkaPort):
+        self.kafka_ip = kafkaIP
+        self.kafka_port = kafkaPort
+        print("Initialized SimulationHelper")
+
+    #Async function that creates a KafkaConsumer and adds all available topics to a list
+    async def kafka_client(self):
+        self.kafka_consumer = AIOKafkaConsumer(
+            bootstrap_servers=[self.kafka_ip+":"+self.kafka_port],
+            auto_offset_reset="latest",
+            enable_auto_commit=True,
+            group_id=None,
+            value_deserializer=lambda x: json.loads(x.decode('utf-8')))
+
+        await self.kafka_consumer.start()
+
+        # Get all kafka topics
+        self.streets_topics = []
+        for topic in await self.kafka_consumer.topics():
+            self.streets_topics.append(topic)
+        print("In createAsyncKafkaConsumer: All available Kafka topics = " + str(self.streets_topics))
+        self.kafka_consumer.subscribe(topics= {"time_sync"})
+        await self.kafka_read()
+
+    #Async function that creates a Kafka Producer and listens for time_sync messages. When a certain time_sync message is received
+    #by the Kafka Consumer, the Kafka Producer will send a desired phase plan to the desired phase plan topic
+    async def kafka_read(self):
+
+        ## Create Kafka producer and send DPP message over DPP topic
+        self.kafka_producer = AIOKafkaProducer(
+            bootstrap_servers=[self.kafka_ip+":"+self.kafka_port],
+            enable_idempotence=True) #When enable_idempotence set to True, the producer will ensure that exactly one copy of each message is written in the stream. 
+            #If False, producer retries due to broker failures, etc., may write duplicates of the retried message in the stream.
+        
+        await self.kafka_producer.start()
+        print("Kafka producer created")
+
+        #Read in messages from Kafka using Consumer
+        try:
+            async for consumed_msg in self.kafka_consumer:
+                print("message consumed {}", consumed_msg.value)
+                #Check the time_sync messages
+                message = {}
+                message["payload"] = consumed_msg.value
+                timestep = message["payload"]["timestep"]
+                print("Timestep {}", timestep)
+                if  timestep == 94300:
+                    desired_phase_plan_json = {
+                        "timestamp" : timestep,
+                        "desired_phase_plan": [
+                            {
+                                "signal_groups": [4],
+                                "start_time": 93300,
+                                "end_time": 98300
+                            },
+                            {
+                                "signal_groups": [2, 6],
+                                "start_time": 102300,
+                                "end_time": 132300
+                            }
+                        ]
+                    }
+                    ### TODO Listen for time synchronization message equal to some value and publish to dpp topic
+                    try:
+                        await self.kafka_producer.send_and_wait("desired_phase_plan", json.dumps(desired_phase_plan_json).encode('utf-8') )
+                    finally:
+                        print("Desired Phase Plan sent successfully")
+                        await self.kafka_producer.stop()        
+        except:
+            print(" In kafka_read: Error reading kafka traffic")
+       
+
+def main():
+    if len(sys.argv) < 3:
+        print('Run with: "python3 simulation_dpp_sender.py kafkaIP kafkaPort"')
+
+        exit()
+    else:   
+        #Read in user input  
+        kafkaIP = sys.argv[1]
+        kafkaPort = sys.argv[2]
+
+        #Create SimulationHelper object
+        simulationHelper = SimulationHelper(kafkaIP, kafkaPort)
+
+        #Create asyncio loop
+        loop = asyncio.get_event_loop()
+
+        #Create individual asyncio task to create kafka client
+        tasks = [
+            loop.create_task(simulationHelper.kafka_client())
+        ]
+
+        #Run asyncio until tasks are complete
+        loop.run_forever()
+        loop.run_until_complete(asyncio.wait(tasks))
+        loop.close()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/simulate_timestep.py
+++ b/scripts/simulate_timestep.py
@@ -1,0 +1,25 @@
+from os import read
+from kafka import KafkaProducer
+import time
+from time import sleep
+import json
+
+
+
+
+if __name__ == "__main__":
+    producer = KafkaProducer(bootstrap_servers=["127.0.0.1:9092"],
+                             value_serializer=lambda x: json.dumps(x).encode('utf-8'))
+    count = 10
+    i = 0
+    start = 2000
+    while(i < count):
+        time_sync_json = {
+        "seq":1, 
+        "timestep":int(start)
+        }
+        producer.send('time_sync', value=time_sync_json)
+        print('Sent a timesync.')
+        i += 1
+        start += 100
+        producer.flush()

--- a/tsc_client_service/src/control_tsc_state.cpp
+++ b/tsc_client_service/src/control_tsc_state.cpp
@@ -81,8 +81,7 @@ namespace traffic_signal_controller_service
 
         hold_execution_time = last_event.end_time;
         tsc_command_queue.push(create_hold_command(empty_group, hold_execution_time, true));
-
-        SPDLOG_DEBUG("Updated queue");
+        SPDLOG_DEBUG("Updated queue with front command {0}!", tsc_command_queue.front().get_cmd_info());
 
     }
 

--- a/tsc_client_service/src/tsc_service.cpp
+++ b/tsc_client_service/src/tsc_service.cpp
@@ -10,6 +10,9 @@ namespace traffic_signal_controller_service {
         }
         try
         {
+            // Temporary fix for bug in CarmaClock::wait_for_initialization(). No mechanism to support notifying multiple threads
+            // of initialization. This fix avoids any threads waiting on initialization.
+            // TODO: Remove initialization and fix issue in carma-time-lib (CarmaClock class) 
             streets_clock_singleton::update(0);
             // Intialize spat kafka producer
             std::string spat_topic_name = streets_configuration::get_string_config("spat_producer_topic");


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Currently when multiple threads call the `streets_clock_singleton` method to retrieve current time before the clock time value has been set for the first time, most will remain block regardless of incoming messages to initialize the clock. This is due to a bug in the https://github.com/usdot-fhwa-stol/carma-time-lib which does not account for notifying multiple threads waiting on initialization. This work-around initializes the clock to 0 at start-up to avoid this problem altogether. Once fixed in the carma-time-lib, this initialization can be removed.

This PR also includes scripts to send time_sync messages and DPP for testing of this functionality at the tsc_service
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix carma-clock functionality so that non of the tsc_service threads are indefinitely blocked on startup.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested during XIL full integration testing in AWS and on local lab ubuntu machines.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
