### PR TITLE
Fix SIMULATION_MODE=FALSE

### DIFF
--- a/tsc_client_service/src/tsc_service.cpp
+++ b/tsc_client_service/src/tsc_service.cpp
@@ -11,9 +11,11 @@ namespace traffic_signal_controller_service {
         try
         {
             // Temporary fix for bug in CarmaClock::wait_for_initialization(). No mechanism to support notifying multiple threads
-            // of initialization. This fix avoids any threads waiting on initialization.
+            // of initialization. This fix avoids any threads waiting on initialization. Only required in SIMULATION_MODE=TRUE
             // TODO: Remove initialization and fix issue in carma-time-lib (CarmaClock class) 
-            streets_clock_singleton::update(0);
+            if ( is_simulation_mode() ) {
+                streets_clock_singleton::update(0);
+            }
             // Intialize spat kafka producer
             std::string spat_topic_name = streets_configuration::get_string_config("spat_producer_topic");
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fix for running the tsc_service in non simulation mode. When running the tsc_service in non simulation mode before this fix, we get an uncaught illegal argument exception from the carma-clock object when trying to update its time to 0. Update calls to carma clock are only valid in simulation mode. This call was temporarily added as a fix for a carma-clock wait for initialization bug that is only present in simulation mode. The fix will only call update if in simulation mode avoiding this exception.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context
K900-XIL Release
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local Integration Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
