### PR TITLE
Remove height and cost-model from RouteGraphBuilder call

### DIFF
--- a/intersection_model/src/intersection_model.cpp
+++ b/intersection_model/src/intersection_model.cpp
@@ -81,12 +81,9 @@ namespace intersection_model
             lanelet::traffic_rules::TrafficRulesFactory::create(lanelet::Locations::Germany,
                                                         lanelet::Participants::Vehicle,
                                                         lanelet::traffic_rules::TrafficRules::Configuration())};
-        lanelet::routing::RoutingCostPtrs costPtrs{
-            std::make_shared<lanelet::routing::RoutingCostDistance>(this->laneChangeCost, this->minLaneChangeLength),
-            std::make_shared<lanelet::routing::RoutingCostTravelTime>(this->laneChangeCost)};
-        lanelet::routing::RoutingGraph::Configuration configuration;
-        configuration.insert(std::make_pair(lanelet::routing::RoutingGraph::ParticipantHeight, this->participantHeight));
-        this->vehicleGraph_ptr = lanelet::routing::RoutingGraph::build(*this->map, *trafficRules, costPtrs, configuration);
+
+        this->vehicleGraph_ptr = lanelet::routing::RoutingGraph::build(*this->map, *trafficRules);
+
         if ( !this->vehicleGraph_ptr )
         {
             return false;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

Height field and cost-model was causing extreme performance issues on building Lanelet2 routegraph by changing calculations for lanelet overlap to be 3D bounding box intersections instead of 2D intersection checks like platform. This change brings an approx. ~5x speed up to the route graph build process and total end-to-end update_intersection_info call.
![image](https://github.com/usdot-fhwa-stol/carma-streets/assets/3723561/17e8fbe7-7c67-4ba2-b395-a73d12a9e978)

![image](https://github.com/usdot-fhwa-stol/carma-streets/assets/3723561/28dae48f-e048-4b69-ae99-0ff67d7302d2)

(%s are percent of total instructions executed when the code was run under Callgrind, representing an approximate measure of performance cost of each function call)

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->
#348 

## Related Jira Key

<!-- e.g. CAR-123 -->
[CDAR-341
](https://usdot-carma.atlassian.net/browse/CDAR-341)
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This significantly reduces the time needed to process the intersection info for an OSM map, by approximately a factor of 5.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested locally under a profiler using the existing unit test suite and the modified version of the Town04 map.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
