### PR TITLE
Fix velocity to speed conversion to account for negative velocities

### DIFF
--- a/sensor_data_sharing_service/src/detected_object_to_sdsm_converter.cpp
+++ b/sensor_data_sharing_service/src/detected_object_to_sdsm_converter.cpp
@@ -80,7 +80,7 @@ namespace sensor_data_sharing_service{
         // Speed confidence
         detected_object._detected_object_common_data._speed_confidence = to_xy_speed_confidence(msg._velocity_covariance);
         // Speed Z
-        detected_object._detected_object_common_data._speed_z = static_cast<unsigned int>(msg._velocity._z* METERS_PER_SECOND_TO_2_CM_PER_SECOND);
+        detected_object._detected_object_common_data._speed_z = static_cast<unsigned int>(fabs(msg._velocity._z)* METERS_PER_SECOND_TO_2_CM_PER_SECOND);
         // Speed Z confidence
         detected_object._detected_object_common_data._speed_z_confidence = to_z_speed_confidence(msg._velocity_covariance);
         // Heading

--- a/sensor_data_sharing_service/test/detected_object_to_sdsm_converter_test.cpp
+++ b/sensor_data_sharing_service/test/detected_object_to_sdsm_converter_test.cpp
@@ -50,8 +50,40 @@ namespace sensor_data_sharing_service {
         EXPECT_EQ(static_cast<unsigned int>(msg._position._y*10), data._detected_object_common_data._position_offset._offset_y);
         EXPECT_EQ(static_cast<unsigned int>(msg._position._y*10), data._detected_object_common_data._position_offset._offset_y);
 
-        EXPECT_EQ(static_cast<unsigned int>(std::hypot(msg._velocity._x*50, msg._velocity._y*50)), data._detected_object_common_data._speed);
-        EXPECT_EQ(static_cast<unsigned int>(msg._velocity._z*50), data._detected_object_common_data._speed_z);
+        EXPECT_EQ(115, data._detected_object_common_data._speed);
+        EXPECT_EQ(260, data._detected_object_common_data._speed_z);
+        EXPECT_EQ(static_cast<unsigned int>(msg._size._length*10), std::get<streets_utils::messages::sdsm::detected_obstacle_data>(data._detected_object_optional_data.value())._size._length);
+
+
+    }
+
+     TEST(detectedObjectToSdsmConverterTest, testToDetectedObjectDataWithNegativeVelocity) {
+        // Create detected object
+        streets_utils::messages::detected_objects_msg::detected_objects_msg msg;
+        msg._object_id = 123;
+        msg._type = "TREE";
+        msg._sensor_id = "sensor_1";
+        msg._proj_string = "some string";
+        msg._confidence = 0.9;
+        msg._velocity = {-0.1, -2.3, -5.2};
+        msg._angular_velocity = {0.1, 2.3, 5.2};
+        msg._position = {0.1, 2.3, 5.2};
+        msg._position_covariance = {{0.1, 2.3, 5.2},{0.1, 2.3, 5.2},{0.1, 2.3, 5.2}};
+        msg._velocity_covariance = {{0.1, 2.3, 5.2},{0.1, 2.3, 5.2},{0.1, 2.3, 5.2}};
+        msg._angular_velocity_covariance = {{0.1, 2.3, 5.2},{0.1, 2.3, 5.2},{0.1, 2.3, 5.2}};
+        msg._size._length =1.1;
+        msg._size._width =1.1;
+        msg._size._height = 10;
+
+        auto data = to_detected_object_data(msg);
+        EXPECT_EQ(msg._object_id, data._detected_object_common_data._object_id);
+        EXPECT_EQ(streets_utils::messages::sdsm::object_type::UNKNOWN, data._detected_object_common_data._object_type);
+        EXPECT_EQ(90, data._detected_object_common_data._classification_confidence);
+        EXPECT_EQ(static_cast<unsigned int>(msg._position._x*10), data._detected_object_common_data._position_offset._offset_x);
+        EXPECT_EQ(static_cast<unsigned int>(msg._position._y*10), data._detected_object_common_data._position_offset._offset_y);
+        EXPECT_EQ(static_cast<unsigned int>(msg._position._y*10), data._detected_object_common_data._position_offset._offset_y);
+        EXPECT_EQ(115, data._detected_object_common_data._speed);
+        EXPECT_EQ(260, data._detected_object_common_data._speed_z);
         EXPECT_EQ(static_cast<unsigned int>(msg._size._length*10), std::get<streets_utils::messages::sdsm::detected_obstacle_data>(data._detected_object_optional_data.value())._size._length);
 
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Account for negative z velocity in detection to SDSM conversion. Take absolute value of z velocity component for conversion
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
<!-- e.g. CAR-123 -->

## Motivation and Context
[CDAR-633
](https://usdot-carma.atlassian.net/browse/CDAR-633)
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
