### PR TITLE
Fix SDSM serialization

### DIFF
--- a/sensor_data_sharing_service/test/detected_object_to_sdsm_converter_test.cpp
+++ b/sensor_data_sharing_service/test/detected_object_to_sdsm_converter_test.cpp
@@ -199,6 +199,9 @@ namespace sensor_data_sharing_service {
         std::vector<std::vector<double>> angular_velocity_covariance = {{4, 2.3, 5.2},{0.1, 4, 5.2},{0.1, 2.3, 9}};
         auto speed_confidence =  to_yaw_rate_confidence(angular_velocity_covariance);
         EXPECT_EQ(streets_utils::messages::sdsm::angular_velocity_confidence::DEGSEC_05,speed_confidence);
+        angular_velocity_covariance = {{0.01, 0.0, 0.0},{0.0, 0.01, 0.0},{0.0, 0.0, 0.01}};
+        speed_confidence =  to_yaw_rate_confidence(angular_velocity_covariance);
+        EXPECT_EQ(streets_utils::messages::sdsm::angular_velocity_confidence::DEGSEC_0_1,speed_confidence);
 
     }
 
@@ -219,7 +222,6 @@ namespace sensor_data_sharing_service {
         EXPECT_NEAR(-2939, to_yaw_rate(-0.513), 1);
 
     }
-
 
 
 }

--- a/sensor_data_sharing_service/test/sensor_data_sharing_service_test.cpp
+++ b/sensor_data_sharing_service/test/sensor_data_sharing_service_test.cpp
@@ -97,36 +97,35 @@ namespace sensor_data_sharing_service {
         const std::string detected_object_json =
             R"(
                 {
-                    "type":"CAR",
-                    "confidence":0.7,
-                    "sensorId":"sensor1",
-                    "projString":"projectionString2",
-                    "objectId":1,
+                    "type":"TRUCK",
+                    "confidence":1.0,
+                    "sensorId":"IntersectionLidar",
+                    "projString":"+proj=tmerc +lat_0=0 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs",
+                    "objectId":222,
                     "position":{
-                        "x":-1.1,
-                        "y":-2.0,
-                        "z":-3.2
+                        "x":-23.70157158620998,
+                        "y":-4.561758806718842,
+                        "z":-9.991932254782586
                     },
-                    "positionCovariance":[[1.0,0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
+                    "positionCovariance":[[0.04000000000000001,0.0,0.0],[0.0,0.04000000000000001,0.0],[0.0,0.0,0.04000000000000001]],
                     "velocity":{
-                        "x":1.0,
-                        "y":1.0,
-                        "z":1.0
+                        "x":0.0,
+                        "y":0.0,
+                        "z":0.0
                     },
-                    "velocityCovariance":[[1.0,0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
+                    "velocityCovariance":[[0.04000000000000001,0.0,0.0],[0.0,0.04000000000000001,0.0],[0.0,0.0,0.04000000000000001]],
                     "angularVelocity":{
-                        "x":0.1,
-                        "y":0.2,
-                        "z":0.3
+                        "x":0.0,
+                        "y":0.0,
+                        "z":0.0
                     },
-                    "angularVelocityCovariance":[[1.0,0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
+                    "angularVelocityCovariance":[[0.010000000000000002,0.0,0.0],[0.0,0.010000000000000002,0.0],[0.0,0.0,0.010000000000000002]],
                     "size":{
-                        "length":2.0,
-                        "height":1.0,
-                        "width":0.5
+                        "length":2.601919174194336,
+                        "height":1.3072861433029175,
+                        "width":1.2337223291397095
                     },
-                    "timestamp":1000
-
+                    "timestamp":41343
                 }
             )";
         auto detected_object = streets_utils::messages::detected_objects_msg::from_json(detected_object_json);
@@ -158,6 +157,8 @@ namespace sensor_data_sharing_service {
         EXPECT_NEAR(calendar_time.tm_min, msg._time_stamp.minute, 1);
         EXPECT_EQ(1 , msg._objects.size());
         EXPECT_EQ(streets_utils::messages::sdsm::object_type::VEHICLE, msg._objects[0]._detected_object_common_data._object_type);
+        EXPECT_TRUE(msg._objects[0]._detected_object_common_data._yaw_rate_confidence.has_value());
+        EXPECT_EQ(streets_utils::messages::sdsm::angular_velocity_confidence::DEGSEC_0_1 , msg._objects[0]._detected_object_common_data._yaw_rate_confidence);
         EXPECT_EQ(serv.detected_objects.size(), 0);
     }
 
@@ -174,5 +175,6 @@ namespace sensor_data_sharing_service {
         EXPECT_EQ(-771470156, position._longitude);
         EXPECT_EQ(10, position._elevation);
     }
+
 
 }

--- a/streets_utils/streets_messages/src/deserializers/sensor_data_sharing_msg_json_deserializer.cpp
+++ b/streets_utils/streets_messages/src/deserializers/sensor_data_sharing_msg_json_deserializer.cpp
@@ -106,18 +106,18 @@ namespace streets_utils::messages::sdsm {
         _detected_object_common_data._heading_confidence = heading_confidence_from_int(parse_uint_member("heading_conf", val, true).value());
         if ( val.HasMember("accel_4_way") )  {
             _detected_object_common_data._acceleration_4_way = parse_acceleration_4_way(parse_object_member("accel_4_way", val, false ).value());
-            if ( val.HasMember("acc_cfd_x")) {
+        }
+         if ( val.HasMember("acc_cfd_x")) {
                 _detected_object_common_data._lateral_acceleration_confidence = acceleration_confidence_from_int(parse_uint_member("acc_cfd_x", val, true).value());
-            }
-            if ( val.HasMember("acc_cfd_y")) {
-                _detected_object_common_data._longitudinal_acceleration_confidence = acceleration_confidence_from_int(parse_uint_member("acc_cfd_y", val, true).value());
-            }
-            if ( val.HasMember("acc_cfd_z")) {
-                _detected_object_common_data._vertical_accelaration_confidence = acceleration_confidence_from_int(parse_uint_member("acc_cfd_z", val, true).value());
-            }
-            if ( val.HasMember("acc_cfd_yaw")) {
-                _detected_object_common_data._yaw_rate_confidence = angular_velocity_confidence_from_int(parse_uint_member("acc_cfd_yaw", val, true).value());
-            }
+        }
+        if ( val.HasMember("acc_cfd_y")) {
+            _detected_object_common_data._longitudinal_acceleration_confidence = acceleration_confidence_from_int(parse_uint_member("acc_cfd_y", val, true).value());
+        }
+        if ( val.HasMember("acc_cfd_z")) {
+            _detected_object_common_data._vertical_accelaration_confidence = acceleration_confidence_from_int(parse_uint_member("acc_cfd_z", val, true).value());
+        }
+        if ( val.HasMember("acc_cfd_yaw")) {
+            _detected_object_common_data._yaw_rate_confidence = angular_velocity_confidence_from_int(parse_uint_member("acc_cfd_yaw", val, true).value());
         }
         return _detected_object_common_data;
     }

--- a/streets_utils/streets_messages/src/deserializers/sensor_data_sharing_msg_json_deserializer.cpp
+++ b/streets_utils/streets_messages/src/deserializers/sensor_data_sharing_msg_json_deserializer.cpp
@@ -107,7 +107,7 @@ namespace streets_utils::messages::sdsm {
         if ( val.HasMember("accel_4_way") )  {
             _detected_object_common_data._acceleration_4_way = parse_acceleration_4_way(parse_object_member("accel_4_way", val, false ).value());
         }
-         if ( val.HasMember("acc_cfd_x")) {
+        if ( val.HasMember("acc_cfd_x")) {
                 _detected_object_common_data._lateral_acceleration_confidence = acceleration_confidence_from_int(parse_uint_member("acc_cfd_x", val, true).value());
         }
         if ( val.HasMember("acc_cfd_y")) {

--- a/streets_utils/streets_messages/src/serializers/sensor_data_sharing_msg_json_serializer.cpp
+++ b/streets_utils/streets_messages/src/serializers/sensor_data_sharing_msg_json_serializer.cpp
@@ -111,13 +111,15 @@ namespace streets_utils::messages::sdsm{
         detected_object_data_common_json.AddMember("pos_confidence", create_position_confidence_set(val._pos_confidence, allocator), allocator );
         detected_object_data_common_json.AddMember("speed", val._speed, allocator);
         detected_object_data_common_json.AddMember("speed_confidence", static_cast<unsigned int >(val._speed_confidence), allocator);
-        if ( val._speed_z.has_value())
+        if ( val._speed_z.has_value()) {
             detected_object_data_common_json.AddMember("speed_z", val._speed_z.value(), allocator);
-        if ( val._speed_z_confidence.has_value())
+        }
+        if ( val._speed_z_confidence.has_value()) {
             detected_object_data_common_json.AddMember(
                     "speed_confidence_z",
                     static_cast<unsigned int >(val._speed_z_confidence.value()),
                     allocator);
+        }
         detected_object_data_common_json.AddMember("heading", val._heading, allocator);
         detected_object_data_common_json.AddMember("heading_conf", static_cast<unsigned int >(val._heading_confidence), allocator);
         if (val._lateral_acceleration_confidence.has_value() ) {
@@ -125,17 +127,20 @@ namespace streets_utils::messages::sdsm{
                     "acc_cfd_x",
                     static_cast<unsigned int >(val._lateral_acceleration_confidence.value()),
                     allocator);
-        if (val._longitudinal_acceleration_confidence.has_value() )
+        }
+        if (val._longitudinal_acceleration_confidence.has_value() ) {
             detected_object_data_common_json.AddMember(
                     "acc_cfd_y",
                     static_cast<unsigned int >(val._longitudinal_acceleration_confidence.value()),
                     allocator);
-        if (val._vertical_accelaration_confidence.has_value())
+        }
+        if (val._vertical_accelaration_confidence.has_value()){
             detected_object_data_common_json.AddMember(
                     "acc_cfd_z",
                     static_cast<unsigned int >(val._vertical_accelaration_confidence.value()),
                     allocator);
-        if (val._yaw_rate_confidence.has_value())
+        }
+        if (val._yaw_rate_confidence.has_value()) {
             detected_object_data_common_json.AddMember(
                     "acc_cfd_yaw",
                     static_cast<unsigned int >(val._yaw_rate_confidence.value()),


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
**NOTE: Depend on CI fix from https://github.com/usdot-fhwa-stol/carma-streets/pull/390**
**Update: PR #390 closed**
CARMA Streets is producing Sensor Data Sharing Messages without yaw rate confidence. This is despite being provided accurate angular acceleration data from simulation. 
```
[2024-01-22 12:52:42.675] [debug] [sensor_data_sharing_service.cpp:102] Detected Object List Size 1 after consumed: {"type":"TRUCK","confidence":1.0,"sensorId":"IntersectionLidar","projString":"+proj=tmerc +lat_0=0 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs","objectId":222,"position":{"x":-23.70157158620998,"y":-4.561758806718842,"z":-9.991932254782586},"positionCovariance":[[0.04000000000000001,0.0,0.0],[0.0,0.04000000000000001,0.0],[0.0,0.0,0.04000000000000001]],"velocity":{"x":0.0,"y":0.0,"z":0.0},"velocityCovariance":[[0.04000000000000001,0.0,0.0],[0.0,0.04000000000000001,0.0],[0.0,0.0,0.04000000000000001]],"angularVelocity":{"x":0.0,"y":0.0,"z":0.0},"angularVelocityCovariance":[[0.010000000000000002,0.0,0.0],[0.0,0.010000000000000002,0.0],[0.0,0.0,0.010000000000000002]],"size":{"length":2.601919174194336,"height":1.3072861433029175,"width":1.2337223291397095},"timestamp":41343}
...
[2024-01-22 12:52:42.675] [debug] [sensor_data_sharing_service.cpp:124] Sending SDSM : {"msg_cnt":0,"source_id":"rsu_1234","equipment_type":1,"sdsm_time_stamp":{"second":9400,"minute":0,"hour":0,"day":1,"month":1,"year":1970,"offset":0},"ref_pos":{"long":23697,"lat":16102,"elevation":100},"ref_pos_xy_conf":{"semi_major":0,"semi_minor":0,"orientation":0},"objects":[{"detected_object_data":{"detected_object_common_data":{"obj_type":1,"object_id":222,"obj_type_cfd":100,"measurement_time":0,"time_confidence":0,"pos":{"offset_x":-237,"offset_y":-45,"offset_z":-99},"pos_confidence":{"pos":10,"elevation":10},"speed":0,"speed_confidence":5,"speed_z":0,"speed_confidence_z":5,"heading":0,"heading_conf":1},"detected_object_optional_data":{"detected_vehicle_data":{"size":{"width":123,"length":260},"height":26}}}}]}
```
Added curly braces to if statements
Added unit test to cover yaw rate confidence serialization Fixed SDSM deserialization to not require acceleration data to write yaw rate confidence
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[CDAR-738
](https://usdot-carma.atlassian.net/browse/CDAR-738)<!-- e.g. CAR-123 -->

## Motivation and Context
Fix SDSM serialization for VRU UC1 testing 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit Testing 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
