### PR TITLE
413: Fix sensor_data_sharing unit test

### DIFF
--- a/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
+++ b/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
@@ -97,7 +97,7 @@ namespace sensor_data_sharing_service {
                 {
                     auto detected_object = streets_utils::messages::detected_objects_msg::from_json(payload);
                     // Get delay of detected object
-                    auto delay = static_cast<uint64_t>(ss::streets_clock_singleton::time_in_ms()) - static_cast<uint64_t>(detected_object._timestamp);
+                    auto delay = static_cast<int64_t>(ss::streets_clock_singleton::time_in_ms()) - static_cast<int64_t>(detected_object._timestamp);
                     SPDLOG_DEBUG("Detection Delay : {0}ms!", delay);
                     // if delay is greater than 500 ms skip detection to get more recent data
                     if ( delay >= 500 ) {

--- a/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
+++ b/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
@@ -97,7 +97,7 @@ namespace sensor_data_sharing_service {
                 {
                     auto detected_object = streets_utils::messages::detected_objects_msg::from_json(payload);
                     // Get delay of detected object
-                    auto delay = static_cast<int>(ss::streets_clock_singleton::time_in_ms()) - static_cast<int>(detected_object._timestamp);
+                    auto delay = static_cast<uint64_t>(ss::streets_clock_singleton::time_in_ms()) - static_cast<uint64_t>(detected_object._timestamp);
                     SPDLOG_DEBUG("Detection Delay : {0}ms!", delay);
                     // if delay is greater than 500 ms skip detection to get more recent data
                     if ( delay >= 500 ) {
@@ -108,15 +108,17 @@ namespace sensor_data_sharing_service {
                     // the detection message was processed before time sync message. Wait on time sync message
                     else if (is_simulation_mode() && delay < 0 ) {
                         SPDLOG_WARN("Current sim time {0} waiting for sim time {1}ms from detection ...",ss::streets_clock_singleton::time_in_ms(), detected_object._timestamp );
-                        ss::streets_clock_singleton::sleep_for(abs(delay));
+                        ss::streets_clock_singleton::sleep_for(delay);
                     }
                     // If delay is negative and service is not in simulation mode
                     // indicates sensor and service are not time sychronized.
                     else if( delay < 0 ) {
                         SPDLOG_WARN(
-                            R"(Current time is {0}ms and detection time stamp is {1}ms. Sensor Data Sharing Service and sensor producing detections to not appear to be time synchronized)",
+                            R"(Skipping incoming detection. Current time is {0}ms and detection time stamp is {1}ms. 
+                                Sensor Data Sharing Service and sensor producing detections to not appear to be time synchronized.)",
                             ss::streets_clock_singleton::time_in_ms(), 
                             detected_object._timestamp );
+                        continue;
 
                     }
 

--- a/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
+++ b/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
@@ -108,7 +108,7 @@ namespace sensor_data_sharing_service {
                     // the detection message was processed before time sync message. Wait on time sync message
                     else if (is_simulation_mode() && delay < 0 ) {
                         SPDLOG_WARN("Current sim time {0} waiting for sim time {1}ms from detection ...",ss::streets_clock_singleton::time_in_ms(), detected_object._timestamp );
-                        ss::streets_clock_singleton::sleep_for(delay);
+                        ss::streets_clock_singleton::sleep_for(abs(delay));
                     }
                     // If delay is negative and service is not in simulation mode
                     // indicates sensor and service are not time sychronized.


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
There was a unit test in the `sensor_data_sharing_service` that started failing on the release candidate. The issue seemed to be that the `int` data type was to small for a delay we were measuring, which caused the number to wrap to a negative number. This negative delay value pushed us unintentionally into a different condition causing the unit test to fail. Below are logs from the failing test case before the changes:
```
[2024-04-08 18:54:18.228] [debug] [streets_service.cpp:136] Reading system config SIMULATION_MODE as : FALSE!
[2024-04-08 18:54:18.228] [info] [streets_singleton.tpp:27] Initializing Singleton of type PN9fwha_stol3lib4time10CarmaClockE!
[2024-04-08 18:54:18.228] [info] [streets_service.cpp:21] Initializing sensor_data_sharing_service streets service in simulation mode : false!
[2024-04-08 18:54:18.228] [warning] [streets_service.cpp:141] System config LOGS_DIRECTORY was not set! Using default value ../logs/!
[2024-04-08 18:54:18.228] [debug] [sensor_data_sharing_service.cpp:41] Intializing Sensor Data Sharing Service
[2024-04-08 18:54:18.228] [debug] [streets_service.cpp:136] Reading system config LANELET2_MAP as : /home/carma-streets/MAP/Intersection.osm!
[2024-04-08 18:54:18.228] [error] [sensor_data_sharing_service.cpp:82] Cannot read osm file /home/carma-streets/MAP/Intersection.osm. Error message: In function parseMapParams:
Errors occured while parsing .osm file: File was not found .
[2024-04-08 18:54:18.228] [error] [sensor_data_sharing_service.cpp:44] Failed to read lanlet2 map /home/carma-streets/MAP/Intersection.osm !
[2024-04-08 18:54:18.229] [debug] [sensor_data_sharing_service.cpp:91] Attempting to consume detections ...
[2024-04-08 18:54:18.229] [error] [sensor_data_sharing_service.cpp:133] Exception occured consuming detection message : Message JSON is misformatted. JSON parsing failed!
/home/carma-streets/sensor_data_sharing_service/test/sensor_data_sharing_service_test.cpp:92: Failure
Expected equality of these values:
  serv.detected_objects.size()
    Which is: 1
  0


GMOCK WARNING:
Uninteresting mock function call - returning directly.
    Function call: stop()
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/main/docs/gmock_cook_book.md#knowing-when-to-expect-useoncall for details.
[  FAILED  ] sensorDataSharingServiceTest.consumeDetections (3 ms)
[----------] 1 test from sensorDataSharingServiceTest (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] sensorDataSharingServiceTest.consumeDetections

 1 FAILED TEST
[2024-04-08 18:54:18.229] [debug] [sensor_data_sharing_service.cpp:101] Detection Delay : -1089493875ms!
[2024-04-08 18:54:18.229] [warning] [sensor_data_sharing_service.cpp:120] Skipping incoming detection. Current time is 1712602458229ms and detection time stamp is 1000ms. 
                                Sensor Data Sharing Service and sensor producing detections to not appear to be time synchronized.
[2024-04-08 18:54:18.229] [debug] [sensor_data_sharing_service.cpp:128] Detected Object List Size 1 after consumed: 
                                                                    {
                                                                        "type":"CAR",
                                                                        "confidence":0.7,
                                                                        "sensorId":"sensor1",
                                                                        "projString":"projectionString2",
                                                                        "objectId":123,
                                                                        "position":{
                                                                            "x":-1.1,
                                                                            "y":-2.0,
                                                                            "z":-3.2
                                                                        },
                                                                        "positionCovariance":[[1.0,0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
                                                                        "velocity":{
                                                                            "x":1.0,
                                                                            "y":1.0,
                                                                            "z":1.0
                                                                        },
                                                                        "velocityCovariance":[[1.0,0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
                                                                        "angularVelocity":{
                                                                            "x":0.1,
                                                                            "y":0.2,
                                                                            "z":0.3
                                                                        },
                                                                        "angularVelocityCovariance":[[1.0,0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
                                                                        "size":{
                                                                            "length":2.0,
                                                                            "height":1.0,
                                                                            "width":0.5
                                                                        },
                                                                        "timestamp":1000
                                                                    }
                                                                    
[2024-04-08 18:54:18.229] [error] [sensor_data_sharing_service.cpp:136] Something went wrong, no longer consuming detections.
[2024-04-08 18:54:18.229] [warning] [sensor_data_sharing_service.cpp:31] Stopping Detection consumer!
[2024-04-08 18:54:18.229] [info] [streets_service.cpp:7] Destructor called for streets service sensor_data_sharing_service!
```

In the example above **current time 1712602458229ms** minus **detection time 1000ms.** evaluates to **-1089493875** due to the size limit of **int**. The changes cast types to **uint_64t** and skip messages in non-simulation mode that have negative delay
<!--- Describe your changes in detail -->

## Related GitHub Issue
#413 
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context
Fix unit test 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit testing 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
