### PR TITLE
Fix detected object JSON processing

### DIFF
--- a/streets_utils/streets_messages/src/deserializers/detected_obj_msg_deserializer.cpp
+++ b/streets_utils/streets_messages/src/deserializers/detected_obj_msg_deserializer.cpp
@@ -107,7 +107,7 @@ namespace streets_utils::messages::detected_objects_msg {
                 if ( val[i][j].IsNull() || !val[i][j].IsNumber())
                 {
                     std::string value = val[i][j].IsNull() ? "null" : val[i][j].GetString();
-                    throw streets_utils::json_utils::json_parse_exception("Covariance matrix contains invalid value" + value + "at position [" + std::to_string(i) + "][" + std::to_string(j) + "]");
+                    throw streets_utils::json_utils::json_parse_exception("Covariance matrix contains invalid value " + value + " at position [" + std::to_string(i) + "][" + std::to_string(j) + "]");
                 }
                 val_row.push_back(val[i][j].GetDouble());
             }

--- a/streets_utils/streets_messages/src/deserializers/detected_obj_msg_deserializer.cpp
+++ b/streets_utils/streets_messages/src/deserializers/detected_obj_msg_deserializer.cpp
@@ -106,7 +106,8 @@ namespace streets_utils::messages::detected_objects_msg {
             {   
                 if ( val[i][j].IsNull() || !val[i][j].IsNumber())
                 {
-                    throw streets_utils::json_utils::json_parse_exception("Covariance matrix contains invalid value at position [" + std::to_string(i) + "][" + std::to_string(j) + "]");
+                    std::string value = val[i][j].IsNull() ? "null" : val[i][j].GetString();
+                    throw streets_utils::json_utils::json_parse_exception("Covariance matrix contains invalid value" + value + "at position [" + std::to_string(i) + "][" + std::to_string(j) + "]");
                 }
                 val_row.push_back(val[i][j].GetDouble());
             }

--- a/streets_utils/streets_messages/src/deserializers/detected_obj_msg_deserializer.cpp
+++ b/streets_utils/streets_messages/src/deserializers/detected_obj_msg_deserializer.cpp
@@ -103,7 +103,11 @@ namespace streets_utils::messages::detected_objects_msg {
             std::vector<double> val_row;
 
             for (rapidjson::SizeType  j = 0; j < row.Size(); j++)
-            {
+            {   
+                if ( val[i][j].IsNull() || !val[i][j].IsNumber())
+                {
+                    throw streets_utils::json_utils::json_parse_exception("Covariance matrix contains invalid value at position [" + std::to_string(i) + "][" + std::to_string(j) + "]");
+                }
                 val_row.push_back(val[i][j].GetDouble());
             }
             covariance.push_back(val_row);

--- a/streets_utils/streets_messages/test/deserializers/detected_obj_msg_deserialization_test.cpp
+++ b/streets_utils/streets_messages/test/deserializers/detected_obj_msg_deserialization_test.cpp
@@ -105,3 +105,45 @@ TEST(detected_obj_msg_deserializer_test, deserialize)
     EXPECT_EQ(msg._timestamp, 1702335309000);
 
 }
+
+
+TEST(detected_obj_msg_deserializer_test, deserializeInvalidCovariance)
+{
+    std::string json_prediction = R"(
+        {
+            "type":"CAR",
+            "confidence":0.7,
+            "sensorId":"sensor1",
+            "projString":"projectionString2",
+            "objectId":27,
+            "position":{
+                "x":-1.1,
+                "y":-2.0,
+                "z":-3.2
+            },
+            "positionCovariance":[["7.1231e-15",0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
+            "velocity":{
+                "x":1.0,
+                "y":1.0,
+                "z":1.0
+            },
+            "velocityCovariance":[["null",0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
+            "angularVelocity":{
+                "x":0.1,
+                "y":0.2,
+                "z":0.3
+            },
+            "angularVelocityCovariance":[[1.0,0.0,0.0],[1.0,0.0,0.0],[1.0,0.0,0.0]],
+            "size":{
+                "length":2.0,
+                "height":1.0,
+                "width":0.5
+            },
+            "timestamp":1702335309000
+        }
+        )";
+
+    EXPECT_THROW(streets_utils::messages::detected_objects_msg::from_json(json_prediction), streets_utils::json_utils::json_parse_exception);
+   
+
+}

--- a/streets_utils/streets_service_base/CMakeLists.txt
+++ b/streets_utils/streets_service_base/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(streets_service_base)
+# Required for inline variable initialization
+set(CMAKE_CXX_STANDARD 17)
 
 ########################################################
 # Find Dependent Packages and set configurations


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Sensor data sharing service would repeated crash with the following failed assertion
```
[2025-05-29 15:10:30.474] [trace] [kafka_producer_worker.h:31] Message dellivery for:  696 bytes [ Success ]
[2025-05-29 15:10:30.474] [trace] [streets_singleton.tpp:12] Singleton class : PN9fwha_stol3lib4time10CarmaClockE.
[2025-05-29 15:10:30.474] [trace] [streets_singleton.tpp:13] Singleton address: 0x55882e4cc3c0
sensor_data_sharing_service: /usr/local/include/rapidjson/document.h:1826: double rapidjson::GenericValue<Encoding, Allocator>::GetDouble() const [with Encoding = rapidjson::UTF8<>;
```
After investigation, it was determined that this was due to small double values being represented in JSON scientific notation (see position covariance)
```
{
  "timestamp": 1748556928940,
  "objectId": 47291,
  "type": "PEDESTRIAN",
  "confidence": 1,
  "sensorId": "FLIRSensor1",
  "projString": "+proj=tmerc +lat_0=0 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs +axis=enu",
  "wgs84Position": {
    "latitude": 38.95502284,
    "longitude": -77.14920843,
    "elevation": 0
  },
  "position": {
    "x": -2.976768904744466,
    "y": 20.775978877186077,
    "z": 0
  },
  "orientation": {
    "x": -0.6560590289905075,
    "y": 0.7547095802227718,
    "z": 0
  },
  "velocity": {
    "x": -2.762394261637902,
    "y": 3.1777710868768483,
    "z": 0
  },
  "size": {
    "length": 0.5,
    "width": 0.6,
    "height": 0
  },
  "positionCovariance": [
    [
      "9.2475556739673363e-05",
      0,
      0
    ],
    [
      0,
      0.01253546224706109,
      0
    ],
    [
      0,
      0,
      0
    ]
  ],
  "velocityCovariance": [
    [
      0.0443226278433012,
      0,
      0
    ],
    [
      0,
      0.0443226278433012,
      0
    ],
    [
      0,
      0,
      1
    ]
  ]
}
``` 

Even though this is an invalid value message handling should discard this message and process the next one instead of crashing. 
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[CDAD-118](https://usdot-carma.atlassian.net/browse/CDAD-118)
<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
After applying this fix I can confirm the service no longer crashes due to this. Below are logs showing this
```
[2025-05-29 18:15:28.768] [trace] [kafka_consumer_worker.cpp:145]  rdkafka#consumer-2 Read message at offset 10806
[2025-05-29 18:15:28.768] [trace] [kafka_consumer_worker.cpp:146]  rdkafka#consumer-2 Message Consumed: 767   bytes ):  {"timestamp":1748556928739,"objectId":47291,"type":"PEDESTRIAN","confidence":1,"sensorId":"FLIRSensor1","projString":"+proj=tmerc +lat_0=0 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs +axis=enu","wgs84Position":{"latitude":38.955018780000003,"longitude":-77.14920438,"elevation":0},"position":{"x":-2.6270139026221839,"y":20.32412891866635,"z":0},"orientation":{"x":-0.69465837045899703,"y":0.71933980033865141,"z":0},"velocity":{"x":-2.2387137089022504,"y":2.3182559094667985,"z":0},"size":{"length":0.5,"width":0.59999999999999998,"height":0},"positionCovariance":[["5.7841043497440117e-05",0,0],[0,0.01196042790726874,0],[0,0,0]],"velocityCovariance":[[0.025965373830511514,0,0],[0,0.025965373830511514,0],[0,0,1]]}
[2025-05-29 18:15:28.769] [error] [sensor_data_sharing_service.cpp:143] Exception occured consuming detection message : Covariance matrix contains invalid value at position [0][0]
[2025-05-29 18:15:28.775] [trace] [streets_singleton.tpp:12] Singleton class : PN9fwha_stol3lib4time10CarmaClockE.
[2025-05-29 18:15:28.775] [trace] [streets_singleton.tpp:13] Singleton address: 0x56245260f3c0
[2025-05-29 18:15:28.870] [trace] [kafka_consumer_worker.cpp:145]  rdkafka#consumer-2 Read message at offset 10807
[2025-05-29 18:15:28.870] [trace] [kafka_consumer_worker.cpp:146]  rdkafka#consumer-2 Message Consumed: 768   bytes ):  {"timestamp":1748556928840,"objectId":47291,"type":"PEDESTRIAN","confidence":1,"sensorId":"FLIRSensor1","projString":"+proj=tmerc +lat_0=0 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs +axis=enu","wgs84Position":{"latitude":38.95502303,"longitude":-77.149205730000006,"elevation":0},"position":{"x":-2.743796431743402,"y":20.796361327487269,"z":0},"orientation":{"x":-0.68199836006249837,"y":0.73135370161917057,"z":0},"velocity":{"x":-2.7070340006691924,"y":2.9029385592905785,"z":0},"size":{"length":0.5,"width":0.59999999999999998,"height":0},"positionCovariance":[["6.8505906282787798e-05",0,0],[0,0.012561719643075652,0],[0,0,0]],"velocityCovariance":[[0.039387713399487781,0,0],[0,0.039387713399487781,0],[0,0,1]]}
[2025-05-29 18:15:28.870] [error] [sensor_data_sharing_service.cpp:143] Exception occured consuming detection message : Covariance matrix contains invalid value at position [0][0]
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[CDAD-118]: https://usdot-carma.atlassian.net/browse/CDAD-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ