### PR TITLE
Build & Push base images before downstream services images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,10 +15,14 @@ jobs:
     uses: usdot-fhwa-stol/actions/.github/workflows/docker.yml@main
     with:
         file: scheduling_service/Dockerfile
+        additional_build_args: |
+          UBUNTU_VERSION=jammy
   signal_opt_service:
     uses: usdot-fhwa-stol/actions/.github/workflows/docker.yml@main
     with:
         file: signal_opt_service/Dockerfile
+        additional_build_args: |
+          UBUNTU_VERSION=jammy
   sensor_data_sharing_service:
     uses: usdot-fhwa-stol/actions/.github/workflows/docker.yml@main
     with:
@@ -27,3 +31,5 @@ jobs:
     uses: usdot-fhwa-stol/actions/.github/workflows/docker.yml@main
     with:
         file: tsc_client_service/Dockerfile
+        additional_build_args: |
+          UBUNTU_VERSION=jammy

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -19,7 +19,7 @@ jobs:
       context: .
       file: streets_service_base/Dockerfile
       image_name: streets_service_base
-      override_tag: jammy  
+      tag_name_suffix: jammy
       additional_build_args: |
         UBUNTU_VERSION=jammy
 
@@ -33,7 +33,7 @@ jobs:
       context: .
       file: streets_service_base_lanelet_aware/Dockerfile
       image_name: streets_service_base
-      override_tag: focal
+      tag_name_suffix: focal
       additional_build_args: |
         UBUNTU_VERSION=focal
 

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - fix_ci_builds
       - master
       - "release/*"
     tags:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -20,8 +20,7 @@ jobs:
       context: .
       file: streets_service_base/Dockerfile
       image_name: streets_service_base
-      tag_name_suffix: jammy
-      replace_suffix: true  
+      override_tag: jammy  
       additional_build_args: |
         UBUNTU_VERSION=jammy
 
@@ -35,14 +34,13 @@ jobs:
       context: .
       file: streets_service_base_lanelet_aware/Dockerfile
       image_name: streets_service_base
-      tag_name_suffix: focal
-      replace_suffix: true  
+      override_tag: focal
       additional_build_args: |
         UBUNTU_VERSION=focal
 
   intersection_model:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -52,7 +50,7 @@ jobs:
       image_name: intersection_model
   message_services:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -101,7 +99,7 @@ jobs:
 
   sensor_data_sharing_service:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -28,7 +28,7 @@ jobs:
       file: message_services/Dockerfile
       image_name: message_services
   tsc_client_service:
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -36,8 +36,12 @@ jobs:
       runner: ubuntu-latest-16-cores
       file: tsc_client_service/Dockerfile
       image_name: tsc_service
+      additional_build_args: |
+        UBUNTU_VERSION=jammy
+        DOCKER_ORG=usdotfhwastolcandidate      
+
   scheduling_service:
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -45,8 +49,11 @@ jobs:
       runner: ubuntu-latest-16-cores
       file: scheduling_service/Dockerfile
       image_name: scheduling_service
+      additional_build_args: |
+        UBUNTU_VERSION=jammy
+        DOCKER_ORG=usdotfhwastolcandidate           
   signal_opt_service:
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -54,6 +61,9 @@ jobs:
       runner: ubuntu-latest-16-cores
       file: signal_opt_service/Dockerfile
       image_name: signal_opt_service
+      additional_build_args: |
+        UBUNTU_VERSION=jammy
+        DOCKER_ORG=usdotfhwastolcandidate           
   sensor_data_sharing_service:
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -20,6 +20,8 @@ jobs:
       context: .
       file: streets_service_base/Dockerfile
       image_name: streets_service_base
+      tag_name_suffix: jammy
+      replace_suffix: true  
       additional_build_args: |
         UBUNTU_VERSION=jammy
 
@@ -33,6 +35,8 @@ jobs:
       context: .
       file: streets_service_base_lanelet_aware/Dockerfile
       image_name: streets_service_base
+      tag_name_suffix: focal
+      replace_suffix: true  
       additional_build_args: |
         UBUNTU_VERSION=focal
 

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       runner: ubuntu-latest-16-cores
       context: .
-      file: docker/streets_service_base/Dockerfile
+      file: streets_service_base/Dockerfile
       image_name: streets_service_base
       additional_build_args: |
         UBUNTU_VERSION=jammy
@@ -31,7 +31,7 @@ jobs:
     with:
       runner: ubuntu-latest-16-cores
       context: .
-      file: docker/streets_service_base/Dockerfile
+      file: streets_service_base_lanelet_aware/Dockerfile
       image_name: streets_service_base
       additional_build_args: |
         UBUNTU_VERSION=focal

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - fix_ci_builds
       - master
       - "release/*"
     tags:
@@ -11,7 +10,7 @@ on:
 
 jobs:
   build_base_jammy:
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -25,7 +24,7 @@ jobs:
         UBUNTU_VERSION=jammy
 
   build_base_focal:
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -40,7 +39,7 @@ jobs:
 
   intersection_model:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -50,7 +49,7 @@ jobs:
       image_name: intersection_model
   message_services:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -60,7 +59,7 @@ jobs:
       image_name: message_services
   tsc_client_service:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -73,7 +72,7 @@ jobs:
 
   scheduling_service:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -86,7 +85,7 @@ jobs:
 
   signal_opt_service:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -99,7 +98,7 @@ jobs:
 
   sensor_data_sharing_service:
     needs: [build_base_jammy, build_base_focal]
-    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -10,7 +10,34 @@ on:
       - "carma-system-*"
 
 jobs:
+  build_base_jammy:
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    with:
+      runner: ubuntu-latest-16-cores
+      context: .
+      file: docker/streets_service_base/Dockerfile
+      image_name: streets_service_base
+      additional_build_args: |
+        UBUNTU_VERSION=jammy
+
+  build_base_focal:
+    uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    with:
+      runner: ubuntu-latest-16-cores
+      context: .
+      file: docker/streets_service_base/Dockerfile
+      image_name: streets_service_base
+      additional_build_args: |
+        UBUNTU_VERSION=focal
+
   intersection_model:
+    needs: [build_base_jammy, build_base_focal]
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -20,6 +47,7 @@ jobs:
       file: intersection_model/Dockerfile
       image_name: intersection_model
   message_services:
+    needs: [build_base_jammy, build_base_focal]
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -29,6 +57,7 @@ jobs:
       file: message_services/Dockerfile
       image_name: message_services
   tsc_client_service:
+    needs: [build_base_jammy, build_base_focal]
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -39,9 +68,9 @@ jobs:
       image_name: tsc_service
       additional_build_args: |
         UBUNTU_VERSION=jammy
-        DOCKER_ORG=usdotfhwastolcandidate      
 
   scheduling_service:
+    needs: [build_base_jammy, build_base_focal]
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -52,8 +81,9 @@ jobs:
       image_name: scheduling_service
       additional_build_args: |
         UBUNTU_VERSION=jammy
-        DOCKER_ORG=usdotfhwastolcandidate           
+
   signal_opt_service:
+    needs: [build_base_jammy, build_base_focal]
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@feature/dockerhub_extra_build_args
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -64,8 +94,9 @@ jobs:
       image_name: signal_opt_service
       additional_build_args: |
         UBUNTU_VERSION=jammy
-        DOCKER_ORG=usdotfhwastolcandidate           
+
   sensor_data_sharing_service:
+    needs: [build_base_jammy, build_base_focal]
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -74,4 +105,3 @@ jobs:
       runner: ubuntu-latest-16-cores
       file: sensor_data_sharing_service/Dockerfile
       image_name: sensor_data_sharing_service
-    


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
CARMA Streets service builds tried to pull `streets_service_base:jammy` or `streets_service_base:focal`,  
but those tags didn’t exist in Docker Hub, causing build failures
 This PR adds two jobs to the CI pipeline:
 • Base image jobs:
   build_base_jammy: pushes streets_service_base:jammy  
   build_base_focal : pushes streets_service_base:focal

• All service-image jobs now need these base jobs, so they only run after
  the tags exist.

These jobs use the new reusable workflow inputs from the `actions` repo: 
     override_tag: jammy | focal  
     additional_build_args: UBUNTU_VERSION=<codename>
     
Before this, service Dockerfiles tried to pull streets_service_base:jammy and :focal,
but those tags didn’t exist in the Docker Hub orgs (dev, candidate, STOL).

Now, New CI changes will builds & pushes the base images first with plain tags (jammy, focal). Service images build next, knowing the required base tags are available.
## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
