### PR TITLE
feat: Add settings necessary to resolve kafka broker ip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-include:
-  # TODO Include V2X Hub docker compose as an OCI (Open Container Initiative) artifact
-  - path: ../V2X-Hub/configuration/docker-compose.yml
+# include:
+#   # TODO Include V2X Hub docker compose as an OCI (Open Container Initiative) artifact
+#   - path: ../V2X-Hub/configuration/docker-compose.yml
 services:
   zookeeper:
     image: wurstmeister/zookeeper
@@ -27,7 +27,12 @@ services:
       retries: 10
     environment:
       DOCKER_HOST_IP:  ${INFRASTRUCTURE_IP:-127.0.0.1}
-      KAFKA_ADVERTISED_HOST_NAME:  ${INFRASTRUCTURE_IP:-127.0.0.1}
+      # Advertise a DNS name rather than an address: containers on the compose
+      # network resolve it via Docker DNS, host-network services via their
+      # extra_hosts entry. Nothing depends on the host's LAN address.
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_PORT: "9092"
+      KAFKA_ADVERTISED_PORT: "9092"
       KAFKA_CREATE_TOPICS: "\
         v2xhub_scheduling_plan_sub:1:1,\
         v2xhub_bsm_in:1:1,\
@@ -60,6 +65,10 @@ services:
     container_name: kowl
     restart: on-failure
     network_mode: host
+    # Host-network services share the host netns; resolve the broker's
+    # advertised name to loopback, where its published port lives.
+    extra_hosts:
+      - "kafka:127.0.0.1"
     profiles: ["debug"]
     depends_on:
       kafka:
@@ -83,6 +92,8 @@ services:
         reservations:
           memory: 1g
     network_mode: host
+    extra_hosts:
+      - "kafka:127.0.0.1"
     profiles: ["vehicle_scheduling", "signal_optimization"]
     depends_on:
       kafka:
@@ -111,6 +122,8 @@ services:
         reservations:
           memory: 1g
     network_mode: host
+    extra_hosts:
+      - "kafka:127.0.0.1"
     profiles : ["vehicle_scheduling", "signal_optimization"]
     depends_on:
       kafka:
@@ -137,6 +150,8 @@ services:
         reservations:
           memory: 1g
     network_mode: host
+    extra_hosts:
+      - "kafka:127.0.0.1"
     profiles: ["vehicle_scheduling", "signal_optimization"]
     depends_on:
       kafka:
@@ -165,6 +180,8 @@ services:
         reservations:
           memory: 1g
     network_mode: host
+    extra_hosts:
+      - "kafka:127.0.0.1"
     profiles: ["signal_optimization"]
     depends_on:
       kafka:
@@ -197,6 +214,8 @@ services:
         reservations:
           memory: 1g
     network_mode: host
+    extra_hosts:
+      - "kafka:127.0.0.1"
     profiles: ["signal_optimization", "vehicle_scheduling"]
     depends_on:
       kafka:
@@ -228,6 +247,8 @@ services:
         reservations:
           memory: 1g
     network_mode: host
+    extra_hosts:
+      - "kafka:127.0.0.1"
     profiles : ["cooperative_perception"]
     depends_on:
       kafka:


### PR DESCRIPTION


<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds several setting necessary for resolving kafka broker ip when running v2xhub on host network.


<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
