### PR TITLE
[DRAFT] test: cover consuming a kafka payload that is not null terminated

### DIFF
--- a/kafka_clients/CMakeLists.txt
+++ b/kafka_clients/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(${BINARY} PUBLIC
                             Boost::thread
                             Boost::filesystem
                             spdlog::spdlog
+                            RdKafka::rdkafka
                             ${PROJECT_NAME}_lib
                             )
 message(CMAKE_VERSION)

--- a/kafka_clients/test/test_kafka_consumer_payload.cpp
+++ b/kafka_clients/test/test_kafka_consumer_payload.cpp
@@ -1,0 +1,97 @@
+#include "gtest/gtest.h"
+#include "kafka_client.h"
+
+#include <librdkafka/rdkafka.h>
+#include <librdkafka/rdkafka_mock.h>
+
+#include <memory>
+#include <string>
+
+/**
+ * @brief Regression test for consuming Kafka payloads that are not null terminated.
+ *
+ * librdkafka payloads carry an explicit length and are owned by the message, so
+ * kafka_consumer_worker::consume() has to size the returned string with
+ * message->len(). A payload containing an embedded null proves the length is
+ * honoured rather than scanned for: read as a C string it stops at the null and
+ * the payload comes back truncated.
+ *
+ * Uses librdkafka's in-process mock cluster, so no broker is required and only
+ * the public API of kafka_consumer_worker is exercised.
+ */
+class kafka_consumer_payload_test : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        std::string err;
+        RdKafka::Conf * conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
+        conf->set("client.id", "mock_cluster_owner", err);
+        cluster_owner.reset(RdKafka::Producer::create(conf, err));
+        delete conf;
+        ASSERT_NE(cluster_owner, nullptr) << err;
+
+        mock_cluster = rd_kafka_mock_cluster_new(cluster_owner->c_ptr(), 1);
+        ASSERT_NE(mock_cluster, nullptr);
+        bootstraps = rd_kafka_mock_cluster_bootstraps(mock_cluster);
+
+        RdKafka::Conf * producer_conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
+        producer_conf->set("bootstrap.servers", bootstraps, err);
+        producer.reset(RdKafka::Producer::create(producer_conf, err));
+        delete producer_conf;
+        ASSERT_NE(producer, nullptr) << err;
+    }
+
+    void TearDown() override
+    {
+        producer.reset();
+        if (mock_cluster) {
+            rd_kafka_mock_cluster_destroy(mock_cluster);
+        }
+        cluster_owner.reset();
+    }
+
+    /// Produce the bytes exactly as given: no terminator added, embedded nulls kept.
+    void produce_raw(const std::string & topic, const std::string & payload)
+    {
+        producer->produce(
+            topic, 0, RdKafka::Producer::RK_MSG_COPY,
+            const_cast<char *>(payload.data()), payload.size(),
+            nullptr, 0, 0, nullptr);
+        producer->flush(1000);
+    }
+
+    std::unique_ptr<RdKafka::Producer> cluster_owner;
+    std::unique_ptr<RdKafka::Producer> producer;
+    rd_kafka_mock_cluster_t * mock_cluster = nullptr;
+    std::string bootstraps;
+};
+
+TEST_F(kafka_consumer_payload_test, consume_preserves_payload_length)
+{
+    // 15 bytes with a null at index 7. Read as a C string this is only 7 bytes long.
+    const std::string payload = std::string("{\"a\":1}") + '\0' + "{\"b\":2}";
+    ASSERT_EQ(payload.size(), 15U);
+
+    const std::string topic = "test_payload_length";
+    auto client = std::make_shared<kafka_clients::kafka_client>();
+    auto consumer = client->create_consumer(bootstraps, topic, "test_payload_group");
+    ASSERT_NE(consumer, nullptr);
+    ASSERT_TRUE(consumer->init());
+    consumer->subscribe();
+
+    // The consumer does not set auto.offset.reset, so it starts at the latest offset.
+    // Keep producing while polling until it has joined the group and been assigned the
+    // partition, otherwise a single up front produce is missed.
+    std::string consumed;
+    for (int attempt = 0; attempt < 40 && consumed.empty(); ++attempt) {
+        produce_raw(topic, payload);
+        consumed = consumer->consume(500);
+    }
+    consumer->stop();
+
+    ASSERT_FALSE(consumed.empty()) << "no message consumed from the mock cluster";
+    // Before the fix this returned only the 7 bytes preceding the null.
+    EXPECT_EQ(consumed.size(), payload.size());
+    EXPECT_EQ(consumed, payload);
+}


### PR DESCRIPTION
# PR Details
## Description

Adds the regression test for the payload truncation fixed in #458. Targets that PR's branch so it merges together with the fix.

The payload is 15 bytes with a null at index 7: `{"a":1}\0{"b":2}`. Read as a C string it is only 7 bytes long, so the test asserts both the length and the full content of what `consume()` returns.

It uses librdkafka's in-process mock cluster (`rd_kafka_mock_cluster_new`), so:
- no broker and no CI change are needed, and
- only the public `consume()` API is exercised, so `msg_consume` stays private.

## Related GitHub Issue

N/A

## Related Jira Key

N/A

## Motivation and Context

The existing `test_kafka_consumer_worker` runs with no broker, so `consume()` returns on the `ERR__TIMED_OUT` branch. The bug lived in the `ERR_NO_ERROR` branch, which no test reached — that test passes identically before and after the fix.

## How Has This Been Tested?

Compiled and run against both versions of `msg_consume` in `usdotfhwastoldev/sensor_data_sharing_service:develop`:

| `msg_consume` | produced | consumed | equal |
|---|---|---|---|
| with the fix (`assign(payload, len())`) | 15 | 15 | yes |
| before the fix (`= static_cast<const char*>(payload())`) | 15 | 7 | no |

Note on timing: `kafka_consumer_worker::init()` does not set `auto.offset.reset`, so the consumer starts at the latest offset. A single produce before subscribing is missed, so the test produces inside the poll loop until the consumer has joined the group and been assigned the partition.

## Types of changes

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
