### PR TITLE
Try stop SDSM producer from dropping detections and publish at up to 10 Hz

### DIFF
--- a/sensor_data_sharing_service/include/sensor_data_sharing_service.hpp
+++ b/sensor_data_sharing_service/include/sensor_data_sharing_service.hpp
@@ -50,6 +50,18 @@
 
 namespace sensor_data_sharing_service {
 
+    /**
+     * @brief Period in milliseconds of the SDSM producer loop. An SDSM is only sent in a cycle that has new detections,
+     * so with a 10 Hz sensor SDSMs are still produced at 10 Hz. Checking at twice the sensor rate makes sure every
+     * detection gets its own cycle despite detection arrival jitter; a 10 Hz loop running alongside a 10 Hz sensor
+     * sometimes finds no new detection in one cycle and two in the next, and drops the older one.
+     */
+    inline constexpr uint64_t SDSM_PRODUCER_PERIOD_MS = 50;
+    /**
+     * @brief Number of SDSM producer cycles between detection metrics writes (once per second).
+     */
+    inline constexpr unsigned int DETECTION_METRICS_WRITE_CYCLES = 1000 / SDSM_PRODUCER_PERIOD_MS;
+
     class sds_service : public streets_service::streets_service {
         private:
             /**
@@ -146,9 +158,11 @@ namespace sensor_data_sharing_service {
             
             /**
              * @brief Method to create SDSM from detected objects.
+             * @param objects Detected objects to include in the SDSM, by object id.
              * @return sensor_data_sharing_msg created from detected objects.
              */
-            streets_utils::messages::sdsm::sensor_data_sharing_msg create_sdsm();
+            streets_utils::messages::sdsm::sensor_data_sharing_msg create_sdsm(
+                const std::map<int,streets_utils::messages::detected_objects_msg::detected_objects_msg> &objects);
 
 
         public:
@@ -171,6 +185,7 @@ namespace sensor_data_sharing_service {
 
             FRIEND_TEST(sensorDataSharingServiceTest, consumeDetections);
             FRIEND_TEST(sensorDataSharingServiceTest, produceSdsms);
+            FRIEND_TEST(sensorDataSharingServiceTest, produceSdsmsKeepsDetectionConsumedDuringSend);
             FRIEND_TEST(sensorDataSharingServiceTest, readLanelet2Map);
             FRIEND_TEST(sensorDataSharingServiceTest, writeDetectionMetrics);
     };

--- a/sensor_data_sharing_service/include/sensor_data_sharing_service.hpp
+++ b/sensor_data_sharing_service/include/sensor_data_sharing_service.hpp
@@ -41,6 +41,8 @@
 #include <lanelet2_projection/UTM.h>
 #include <map>
 #include <shared_mutex>
+#include <condition_variable>
+#include <chrono>
 #include <deque>
 
 #include "detected_object_to_sdsm_converter.hpp"
@@ -51,16 +53,15 @@
 namespace sensor_data_sharing_service {
 
     /**
-     * @brief Period in milliseconds of the SDSM producer loop. An SDSM is only sent in a cycle that has new detections,
-     * so with a 10 Hz sensor SDSMs are still produced at 10 Hz. Checking at twice the sensor rate makes sure every
-     * detection gets its own cycle despite detection arrival jitter; a 10 Hz loop running alongside a 10 Hz sensor
-     * sometimes finds no new detection in one cycle and two in the next, and drops the older one.
+     * @brief Minimum time in milliseconds between SDSMs (SDSMs are published at up to 10 Hz). Detections are
+     * published as soon as they arrive if the last SDSM was at least this long ago; detections that arrive sooner
+     * are held and published together when the period ends.
      */
-    inline constexpr uint64_t SDSM_PRODUCER_PERIOD_MS = 50;
+    inline constexpr uint64_t SDSM_PUBLISH_PERIOD_MS = 100;
     /**
-     * @brief Number of SDSM producer cycles between detection metrics writes (once per second).
+     * @brief Time in milliseconds between detection metrics writes.
      */
-    inline constexpr unsigned int DETECTION_METRICS_WRITE_CYCLES = 1000 / SDSM_PRODUCER_PERIOD_MS;
+    inline constexpr uint64_t DETECTION_METRICS_WRITE_PERIOD_MS = 1000;
 
     class sds_service : public streets_service::streets_service {
         private:
@@ -80,6 +81,15 @@ namespace sensor_data_sharing_service {
              * @brief Mutex for thread safe operations on detected objects map.
              */
             std::shared_mutex detected_objects_lock;
+            /**
+             * @brief Notified by the detection consumer when a detection is added to detected_objects, so the SDSM
+             * producer can publish it without waiting for a fixed loop period.
+             */
+            std::condition_variable_any detections_available;
+            /**
+             * @brief Time in milliseconds the last SDSM was published.
+             */
+            uint64_t _last_sdsm_publish_ms = 0;
             /**
              * @brief Lanelet2 Map pointer
              */
@@ -142,8 +152,9 @@ namespace sensor_data_sharing_service {
              */
             void consume_detections();
             /**
-             * @brief Loop to produce sensor data sharing messages from detected_objects. Loop will populate sensor data sharing message with 
-             * most recent detection information, publish message and clear detected object map. Will terminate if kafka producer is no longer
+             * @brief Loop to produce sensor data sharing messages from detected_objects. Waits for detections and publishes
+             * them in an SDSM (the most recent detection of each object), at most once per SDSM_PUBLISH_PERIOD_MS: immediately if
+             * the period since the last SDSM has ended, otherwise when it ends. Will terminate if kafka producer is no longer
              * running.
              * 
              * @throws std::runtime exception if sdsm_producer == nullptr
@@ -186,6 +197,8 @@ namespace sensor_data_sharing_service {
             FRIEND_TEST(sensorDataSharingServiceTest, consumeDetections);
             FRIEND_TEST(sensorDataSharingServiceTest, produceSdsms);
             FRIEND_TEST(sensorDataSharingServiceTest, produceSdsmsKeepsDetectionConsumedDuringSend);
+            FRIEND_TEST(sensorDataSharingServiceTest, produceSdsmsPublishesImmediatelyAfterPeriod);
+            FRIEND_TEST(sensorDataSharingServiceTest, produceSdsmsHoldsDetectionsWithinPeriod);
             FRIEND_TEST(sensorDataSharingServiceTest, readLanelet2Map);
             FRIEND_TEST(sensorDataSharingServiceTest, writeDetectionMetrics);
     };

--- a/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
+++ b/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
@@ -197,13 +197,21 @@ namespace sensor_data_sharing_service {
         }
         SPDLOG_INFO("Starting SDSM Producer!");
         unsigned int  _interation =0;
+        uint64_t next_cycle_ms = ss::streets_clock_singleton::time_in_ms();
         while ( sdsm_producer->is_running() ) {
             try{
-                if (this->_record_detection_metrics && _interation % 10 == 0) {
+                if (this->_record_detection_metrics && _interation % DETECTION_METRICS_WRITE_CYCLES == 0) {
                     write_detection_metrics(_detection_metrics_logger, _detection_metrics, DETECTION_METRICS_HEADER, _detection_metrics_lock);
                 }
-                if ( !detected_objects.empty() ) {
-                    streets_utils::messages::sdsm::sensor_data_sharing_msg msg = create_sdsm();
+                // Take all detections consumed since the last cycle in one locked step. A detection consumed while
+                // this SDSM is built and sent stays in detected_objects for the next cycle instead of being cleared unsent.
+                std::map<int,streets_utils::messages::detected_objects_msg::detected_objects_msg> objects;
+                {
+                    std::unique_lock lock(detected_objects_lock);
+                    objects.swap(detected_objects);
+                }
+                if ( !objects.empty() ) {
+                    streets_utils::messages::sdsm::sensor_data_sharing_msg msg = create_sdsm(objects);
                     const std::string json_msg = streets_utils::messages::sdsm::to_json(msg);
                     SPDLOG_DEBUG("Sending SDSM : {0}", json_msg);
                     sdsm_producer->send(json_msg);
@@ -213,10 +221,6 @@ namespace sensor_data_sharing_service {
                     }else {
                         this->_message_count = 0;
                     }
-                    // Write Lock 
-                    std::unique_lock lock(detected_objects_lock);
-                    // Clear detected object
-                    detected_objects.clear();
                 }
             }
             catch( const streets_utils::json_utils::json_parse_exception &e) {
@@ -224,18 +228,26 @@ namespace sensor_data_sharing_service {
                 if (this->_record_detection_metrics) {
                     increment_drop_metric(_detection_metrics, DETECTION_METRICS_HEADER[3], _detection_metrics_lock);
                 }
-            }         
+            }
             _interation++;
-            ss::streets_clock_singleton::sleep_for(100); // Sleep for 100 ms between publish  
+            // Fixed-rate loop: sleep until the next cycle's start, not a fixed time after this cycle's work, so the
+            // loop doesn't drift slower than its period. If a cycle overran, restart the schedule from now rather
+            // than running back-to-back cycles to catch up.
+            next_cycle_ms += SDSM_PRODUCER_PERIOD_MS;
+            const uint64_t now_ms = ss::streets_clock_singleton::time_in_ms();
+            if ( next_cycle_ms < now_ms ) {
+                next_cycle_ms = now_ms;
+            }
+            ss::streets_clock_singleton::sleep_until(next_cycle_ms);
         }
         SPDLOG_CRITICAL("SDSM Producers no longer running.");
        
     }
 
-    streets_utils::messages::sdsm::sensor_data_sharing_msg sds_service::create_sdsm() {
+    streets_utils::messages::sdsm::sensor_data_sharing_msg sds_service::create_sdsm(
+        const std::map<int,streets_utils::messages::detected_objects_msg::detected_objects_msg> &objects) {
         const std::string ref_proj_string = ss::streets_configuration::get_string_config("reference_proj_string");
         streets_utils::messages::sdsm::sensor_data_sharing_msg msg;
-        // Read lock
         uint64_t timestamp = ss::streets_clock_singleton::time_in_ms();
         msg._time_stamp = to_sdsm_timestamp(timestamp);
         // Populate with rolling counter
@@ -246,8 +258,7 @@ namespace sensor_data_sharing_service {
         msg._equipment_type = sdsm::equipment_type::RSU;
         // Populate ref position
         msg._ref_positon = to_position_3d(this->sdsm_reference_point);
-        std::shared_lock lock(detected_objects_lock);
-        for (const auto &[object_id, object] : detected_objects){
+        for (const auto &[object_id, object] : objects){
             try {
                 auto transformed_object_data = detected_object_local_to_ref(object, ref_proj_string);
                 auto ned_object = detected_object_enu_to_ned(transformed_object_data);

--- a/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
+++ b/sensor_data_sharing_service/src/sensor_data_sharing_service.cpp
@@ -173,11 +173,18 @@ namespace sensor_data_sharing_service {
 
                     }
 
-                    // Write Lock
-                    std::unique_lock lock(detected_objects_lock);
-                    detected_objects[detected_object._object_id] = detected_object;
-                    SPDLOG_DEBUG("Detected Object List Size {0} after consumed: {1}", detected_objects.size(), payload);
-                    
+                    {
+                        // Write Lock
+                        std::unique_lock lock(detected_objects_lock);
+                        // A newer detection of an object replaces one still waiting to be published
+                        if (this->_record_detection_metrics && detected_objects.count(detected_object._object_id)) {
+                            increment_drop_metric(_detection_metrics, DETECTION_METRICS_HEADER[1], _detection_metrics_lock);
+                        }
+                        detected_objects[detected_object._object_id] = detected_object;
+                        SPDLOG_DEBUG("Detected Object List Size {0} after consumed: {1}", detected_objects.size(), payload);
+                    }
+                    detections_available.notify_one();
+
                 }
             }
             catch (const streets_utils::json_utils::json_parse_exception &e) {
@@ -196,19 +203,37 @@ namespace sensor_data_sharing_service {
             throw std::runtime_error("SDSM consumer is null!");
         }
         SPDLOG_INFO("Starting SDSM Producer!");
-        unsigned int  _interation =0;
-        uint64_t next_cycle_ms = ss::streets_clock_singleton::time_in_ms();
+        uint64_t last_metrics_write_ms = 0;
         while ( sdsm_producer->is_running() ) {
             try{
-                if (this->_record_detection_metrics && _interation % DETECTION_METRICS_WRITE_CYCLES == 0) {
+                if (this->_record_detection_metrics
+                        && ss::streets_clock_singleton::time_in_ms() >= last_metrics_write_ms + DETECTION_METRICS_WRITE_PERIOD_MS) {
                     write_detection_metrics(_detection_metrics_logger, _detection_metrics, DETECTION_METRICS_HEADER, _detection_metrics_lock);
+                    last_metrics_write_ms = ss::streets_clock_singleton::time_in_ms();
                 }
-                // Take all detections consumed since the last cycle in one locked step. A detection consumed while
-                // this SDSM is built and sent stays in detected_objects for the next cycle instead of being cleared unsent.
                 std::map<int,streets_utils::messages::detected_objects_msg::detected_objects_msg> objects;
                 {
                     std::unique_lock lock(detected_objects_lock);
-                    objects.swap(detected_objects);
+                    // Wait for a detection. The wait is bounded so is_running() and the metrics are still checked
+                    // when no detections arrive.
+                    detections_available.wait_for(lock, std::chrono::milliseconds(SDSM_PUBLISH_PERIOD_MS),
+                        [this]{ return !detected_objects.empty(); });
+                    if ( !detected_objects.empty() ) {
+                        // Publish at most once per period. A detection that arrives after the period has ended is
+                        // published immediately; one that arrives within it is held until the period ends, together
+                        // with any detections that arrive meanwhile (a newer detection of an object replaces its
+                        // older one). The wait uses the streets clock so it also follows simulation time.
+                        const uint64_t earliest_publish_ms = _last_sdsm_publish_ms + SDSM_PUBLISH_PERIOD_MS;
+                        if ( ss::streets_clock_singleton::time_in_ms() < earliest_publish_ms ) {
+                            lock.unlock();
+                            ss::streets_clock_singleton::sleep_until(earliest_publish_ms);
+                            lock.lock();
+                        }
+                        // Take all waiting detections in one locked step, so a detection consumed while this SDSM is
+                        // built and sent stays in detected_objects for the next SDSM instead of being cleared unsent.
+                        objects.swap(detected_objects);
+                        _last_sdsm_publish_ms = ss::streets_clock_singleton::time_in_ms();
+                    }
                 }
                 if ( !objects.empty() ) {
                     streets_utils::messages::sdsm::sensor_data_sharing_msg msg = create_sdsm(objects);
@@ -229,16 +254,6 @@ namespace sensor_data_sharing_service {
                     increment_drop_metric(_detection_metrics, DETECTION_METRICS_HEADER[3], _detection_metrics_lock);
                 }
             }
-            _interation++;
-            // Fixed-rate loop: sleep until the next cycle's start, not a fixed time after this cycle's work, so the
-            // loop doesn't drift slower than its period. If a cycle overran, restart the schedule from now rather
-            // than running back-to-back cycles to catch up.
-            next_cycle_ms += SDSM_PRODUCER_PERIOD_MS;
-            const uint64_t now_ms = ss::streets_clock_singleton::time_in_ms();
-            if ( next_cycle_ms < now_ms ) {
-                next_cycle_ms = now_ms;
-            }
-            ss::streets_clock_singleton::sleep_until(next_cycle_ms);
         }
         SPDLOG_CRITICAL("SDSM Producers no longer running.");
        

--- a/sensor_data_sharing_service/test/sensor_data_sharing_service_test.cpp
+++ b/sensor_data_sharing_service/test/sensor_data_sharing_service_test.cpp
@@ -172,10 +172,7 @@ namespace sensor_data_sharing_service {
         EXPECT_NEAR( msg._objects[0]._detected_object_common_data._heading, 7200, 2);
     }
 
-    TEST(sensorDataSharingServiceTest, produceSdsmsKeepsDetectionConsumedDuringSend) {
-        sds_service serv;
-        serv._infrastructure_id = "rsu_1234";
-        streets_service::streets_clock_singleton::create(false);
+    streets_utils::messages::detected_objects_msg::detected_objects_msg detection_for_test(int object_id) {
         const std::string detected_object_json =
             R"(
                 {
@@ -194,9 +191,17 @@ namespace sensor_data_sharing_service {
                     "timestamp":41343
                 }
             )";
-        auto first_detection = streets_utils::messages::detected_objects_msg::from_json(detected_object_json);
-        auto second_detection = first_detection;
-        second_detection._object_id = 223;
+        auto detection = streets_utils::messages::detected_objects_msg::from_json(detected_object_json);
+        detection._object_id = object_id;
+        return detection;
+    }
+
+    TEST(sensorDataSharingServiceTest, produceSdsmsKeepsDetectionConsumedDuringSend) {
+        sds_service serv;
+        serv._infrastructure_id = "rsu_1234";
+        streets_service::streets_clock_singleton::create(false);
+        const auto first_detection = detection_for_test(222);
+        const auto second_detection = detection_for_test(223);
         serv.detected_objects[first_detection._object_id] = first_detection;
 
         serv.sdsm_producer = std::make_shared<kafka_clients::mock_kafka_producer_worker>();
@@ -206,15 +211,21 @@ namespace sensor_data_sharing_service {
                                                     .WillOnce(Return(true))
                                                     .WillRepeatedly(Return(false));
         // The second detection is consumed while the first SDSM is being sent. It must be sent in the next SDSM,
-        // not cleared along with the detections of the SDSM that was just sent.
+        // not cleared along with the detections of the SDSM that was just sent, and no sooner than one period later.
         std::string first_sdsm_json;
         std::string second_sdsm_json;
+        uint64_t first_publish_ms = 0;
+        uint64_t second_publish_ms = 0;
         EXPECT_CALL(producer, send(_)).Times(2)
             .WillOnce(testing::Invoke([&](const std::string &msg) {
                 first_sdsm_json = msg;
+                first_publish_ms = serv._last_sdsm_publish_ms;
                 serv.detected_objects[second_detection._object_id] = second_detection;
             }))
-            .WillOnce(SaveArg<0>(&second_sdsm_json));
+            .WillOnce(testing::Invoke([&](const std::string &msg) {
+                second_sdsm_json = msg;
+                second_publish_ms = serv._last_sdsm_publish_ms;
+            }));
         serv.produce_sdsms();
 
         auto first_sdsm = streets_utils::messages::sdsm::from_json(first_sdsm_json);
@@ -223,6 +234,46 @@ namespace sensor_data_sharing_service {
         EXPECT_EQ(222, first_sdsm._objects[0]._detected_object_common_data._object_id);
         ASSERT_EQ(1, second_sdsm._objects.size());
         EXPECT_EQ(223, second_sdsm._objects[0]._detected_object_common_data._object_id);
+        EXPECT_GE(second_publish_ms - first_publish_ms, SDSM_PUBLISH_PERIOD_MS);
+        EXPECT_EQ(serv.detected_objects.size(), 0);
+    }
+
+    TEST(sensorDataSharingServiceTest, produceSdsmsPublishesImmediatelyAfterPeriod) {
+        sds_service serv;
+        serv._infrastructure_id = "rsu_1234";
+        streets_service::streets_clock_singleton::create(false);
+        // Last SDSM was longer than one period ago, so a new detection must not wait for a loop period
+        serv._last_sdsm_publish_ms = streets_service::streets_clock_singleton::time_in_ms() - 5 * SDSM_PUBLISH_PERIOD_MS;
+        serv.detected_objects[222] = detection_for_test(222);
+
+        serv.sdsm_producer = std::make_shared<kafka_clients::mock_kafka_producer_worker>();
+        auto &producer = dynamic_cast<kafka_clients::mock_kafka_producer_worker&>(*serv.sdsm_producer);
+        EXPECT_CALL(producer, is_running()).Times(2).WillOnce(Return(true)).WillRepeatedly(Return(false));
+        EXPECT_CALL(producer, send(_)).Times(1);
+        const auto start = std::chrono::steady_clock::now();
+        serv.produce_sdsms();
+        const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+
+        EXPECT_LT(elapsed_ms, static_cast<int64_t>(SDSM_PUBLISH_PERIOD_MS / 2));
+        EXPECT_EQ(serv.detected_objects.size(), 0);
+    }
+
+    TEST(sensorDataSharingServiceTest, produceSdsmsHoldsDetectionsWithinPeriod) {
+        sds_service serv;
+        serv._infrastructure_id = "rsu_1234";
+        streets_service::streets_clock_singleton::create(false);
+        // An SDSM was just published, so a new detection must be held until the period ends
+        const uint64_t previous_publish_ms = streets_service::streets_clock_singleton::time_in_ms();
+        serv._last_sdsm_publish_ms = previous_publish_ms;
+        serv.detected_objects[222] = detection_for_test(222);
+
+        serv.sdsm_producer = std::make_shared<kafka_clients::mock_kafka_producer_worker>();
+        auto &producer = dynamic_cast<kafka_clients::mock_kafka_producer_worker&>(*serv.sdsm_producer);
+        EXPECT_CALL(producer, is_running()).Times(2).WillOnce(Return(true)).WillRepeatedly(Return(false));
+        EXPECT_CALL(producer, send(_)).Times(1);
+        serv.produce_sdsms();
+
+        EXPECT_GE(serv._last_sdsm_publish_ms - previous_publish_ms, SDSM_PUBLISH_PERIOD_MS);
         EXPECT_EQ(serv.detected_objects.size(), 0);
     }
 

--- a/sensor_data_sharing_service/test/sensor_data_sharing_service_test.cpp
+++ b/sensor_data_sharing_service/test/sensor_data_sharing_service_test.cpp
@@ -172,6 +172,60 @@ namespace sensor_data_sharing_service {
         EXPECT_NEAR( msg._objects[0]._detected_object_common_data._heading, 7200, 2);
     }
 
+    TEST(sensorDataSharingServiceTest, produceSdsmsKeepsDetectionConsumedDuringSend) {
+        sds_service serv;
+        serv._infrastructure_id = "rsu_1234";
+        streets_service::streets_clock_singleton::create(false);
+        const std::string detected_object_json =
+            R"(
+                {
+                    "type":"TRUCK",
+                    "confidence":1.0,
+                    "sensorId":"IntersectionLidar",
+                    "projString":"+proj=tmerc +lat_0=0 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs",
+                    "objectId":222,
+                    "position":{"x":-23.7,"y":-4.5,"z":-9.9},
+                    "positionCovariance":[[0.04,0.0,0.0],[0.0,0.04,0.0],[0.0,0.0,0.04]],
+                    "velocity":{"x":1.0,"y":0.0,"z":0.0},
+                    "velocityCovariance":[[0.04,0.0,0.0],[0.0,0.04,0.0],[0.0,0.0,0.04]],
+                    "angularVelocity":{"x":0.0,"y":0.0,"z":0.0},
+                    "angularVelocityCovariance":[[0.01,0.0,0.0],[0.0,0.01,0.0],[0.0,0.0,0.01]],
+                    "size":{"length":2.6,"height":1.3,"width":1.2},
+                    "timestamp":41343
+                }
+            )";
+        auto first_detection = streets_utils::messages::detected_objects_msg::from_json(detected_object_json);
+        auto second_detection = first_detection;
+        second_detection._object_id = 223;
+        serv.detected_objects[first_detection._object_id] = first_detection;
+
+        serv.sdsm_producer = std::make_shared<kafka_clients::mock_kafka_producer_worker>();
+        auto &producer = dynamic_cast<kafka_clients::mock_kafka_producer_worker&>(*serv.sdsm_producer);
+        EXPECT_CALL(producer, is_running()).Times(4).WillOnce(Return(true))
+                                                    .WillOnce(Return(true))
+                                                    .WillOnce(Return(true))
+                                                    .WillRepeatedly(Return(false));
+        // The second detection is consumed while the first SDSM is being sent. It must be sent in the next SDSM,
+        // not cleared along with the detections of the SDSM that was just sent.
+        std::string first_sdsm_json;
+        std::string second_sdsm_json;
+        EXPECT_CALL(producer, send(_)).Times(2)
+            .WillOnce(testing::Invoke([&](const std::string &msg) {
+                first_sdsm_json = msg;
+                serv.detected_objects[second_detection._object_id] = second_detection;
+            }))
+            .WillOnce(SaveArg<0>(&second_sdsm_json));
+        serv.produce_sdsms();
+
+        auto first_sdsm = streets_utils::messages::sdsm::from_json(first_sdsm_json);
+        auto second_sdsm = streets_utils::messages::sdsm::from_json(second_sdsm_json);
+        ASSERT_EQ(1, first_sdsm._objects.size());
+        EXPECT_EQ(222, first_sdsm._objects[0]._detected_object_common_data._object_id);
+        ASSERT_EQ(1, second_sdsm._objects.size());
+        EXPECT_EQ(223, second_sdsm._objects[0]._detected_object_common_data._object_id);
+        EXPECT_EQ(serv.detected_objects.size(), 0);
+    }
+
     TEST(sensorDataSharingServiceTest,readLanelet2Map) {
         sds_service serv;
         EXPECT_TRUE(serv.read_lanelet_map("/home/carma-streets/sample_map/town01_vector_map_test.osm"));


### PR DESCRIPTION
# PR Details
## Description

Stops the sensor data sharing service's SDSM producer from dropping detections, and publishes SDSMs at up to 10 Hz as detections arrive:

1. **Rate-limited, detection-driven publishing.** The detection consumer notifies the producer after each detection. If the last SDSM was at least 100 ms ago (`SDSM_PUBLISH_PERIOD_MS`), the producer publishes right away; otherwise it holds the detections until 100 ms after the last SDSM and publishes everything that arrived meanwhile. No two SDSMs are less than 100 ms apart, and no detection waits for a fixed loop period.
<img width="847" height="539" alt="image" src="https://github.com/user-attachments/assets/05823c6c-d22a-4405-b95c-936e320e6094" />

2. **Atomic take of detections.** The producer swaps `detected_objects` out under the write lock and builds the SDSM from that snapshot (`create_sdsm` now takes the objects map), so detections consumed while an SDSM is built and sent are kept for the next SDSM.
3. A newer detection of an object replaces one still waiting to be published, as before; the replaced detection is now counted in `Detection Drop Count`.
4. The producer's wait is bounded to 100 ms, so `is_running()` and the detection metrics (written on a 1 s timer) are still checked when no detections arrive. The hold uses `streets_clock_singleton`, so it follows simulation time.
5. New tests: a detection consumed during a send is published in the next SDSM ≥ 100 ms later; a detection is published immediately after the period and held within it.

## Related GitHub Issue

N/A

## Related Jira Key

N/A

## Motivation and Context

The producer slept 100 ms *after* each cycle's work (~101 ms per cycle) next to a 10 Hz sensor, with nothing keeping them aligned. With detection arrival jitter, a cycle sometimes found no new detection and the next found two, and `detected_objects` keeps only the newest per object. A detection consumed between building the SDSM and `detected_objects.clear()` was also erased unsent.

Old logic (actual service output on `release/wrangler`) vs. new logic (replayed on the same detection consume times from the service log), for the 2026-09-10 data-verification test session, 13:00–14:05 ET, FLIR camera at 10 Hz:

| | Old | New |
|---|---|---|
| Detections never published, test session (6,541) | 4.8% | 0.6% |
| Detections never published, 4 engaged test runs (832) | 8.9% | 0.2% |
| SDSM rate while detecting | 9.5 Hz | 9.9 Hz |
| SDSM gaps of 100–110 ms | 95.6% | 98.9% |
| Skipped 100 ms slots (gap > 140 ms) | 4.4% | 0.7% |
| SDSM gaps under 100 ms | 0% | 0% |
| Detection age at publish, median / p95 | 66 / 113 ms | 49 / 97 ms |

## How Has This Been Tested?

- `sensor_data_sharing_service.cpp` and `sensor_data_sharing_service_test.cpp` compile (`g++ -std=c++17 -fsyntax-only` against the repo headers).
- The unit tests have **not** been run: the full build needs the carma-streets Docker toolchain, which wasn't available. CI on this branch is the check.
- The old-vs-new numbers compare the old service's logged SDSMs with a replay of the new publishing rule on the same logged consume times.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
